### PR TITLE
Support setting locale in MCP Server

### DIFF
--- a/cmd/wolt-mcp/main.go
+++ b/cmd/wolt-mcp/main.go
@@ -47,8 +47,6 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
-	// Position-dependent arg parsing is intentional: only one --flag is ever
-	// passed by MCP clients, so a simple os.Args scan is sufficient.
 	locale := resolveLocale()
 
 	if len(os.Args) > 1 {
@@ -127,8 +125,10 @@ func resolveWoltRequestMinInterval() time.Duration {
 }
 
 func resolveLocale() string {
-	if len(os.Args) > 2 && os.Args[1] == "--locale" {
-		return strings.TrimSpace(os.Args[2])
+	for i, arg := range os.Args {
+		if arg == "--locale" && i+1 < len(os.Args) {
+			return strings.TrimSpace(os.Args[i+1])
+		}
 	}
 	raw := strings.TrimSpace(os.Getenv(localeEnv))
 	if raw != "" {

--- a/cmd/wolt-mcp/main.go
+++ b/cmd/wolt-mcp/main.go
@@ -47,6 +47,8 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	// Position-dependent arg parsing is intentional: only one --flag is ever
+	// passed by MCP clients, so a simple os.Args scan is sufficient.
 	locale := resolveLocale()
 
 	if len(os.Args) > 1 {
@@ -56,13 +58,6 @@ func main() {
 			return
 		case "--help", "-h", "help":
 			printHelp()
-			return
-		case "--locale":
-			if len(os.Args) > 2 {
-				fmt.Println(strings.TrimSpace(os.Args[2]))
-			} else {
-				fmt.Println(locale)
-			}
 			return
 		}
 	}
@@ -105,7 +100,6 @@ Usage:
   wolt-mcp              Run the MCP server over stdio.
   wolt-mcp --version    Print version and exit.
   wolt-mcp --help       Print this message and exit.
-  wolt-mcp --locale     Print the active locale and exit.
 
 Options:
   --locale <bcp47>      Response locale in BCP-47 format (default: en-FI).

--- a/cmd/wolt-mcp/main.go
+++ b/cmd/wolt-mcp/main.go
@@ -34,6 +34,8 @@ var version = "dev"
 const (
 	defaultWoltHTTPMinInterval = 220 * time.Millisecond
 	woltHTTPMinIntervalEnv     = "WOLT_HTTP_MIN_INTERVAL_MS"
+	defaultLocale              = "en-FI"
+	localeEnv                  = "WOLT_LOCALE"
 )
 
 func main() {
@@ -45,6 +47,8 @@ func main() {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 	slog.SetDefault(logger)
 
+	locale := resolveLocale()
+
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
 		case "--version", "-v", "version":
@@ -52,6 +56,13 @@ func main() {
 			return
 		case "--help", "-h", "help":
 			printHelp()
+			return
+		case "--locale":
+			if len(os.Args) > 2 {
+				fmt.Println(strings.TrimSpace(os.Args[2]))
+			} else {
+				fmt.Println(locale)
+			}
 			return
 		}
 	}
@@ -64,6 +75,7 @@ func main() {
 
 	wolt := woltgateway.NewClient(
 		woltgateway.WithRequestMinInterval(resolveWoltRequestMinInterval()),
+		woltgateway.WithLocale(locale),
 	)
 
 	deps := mcpserver.Deps{
@@ -72,6 +84,7 @@ func main() {
 		Location: locationgateway.NewClient(),
 		Config:   store,
 		Version:  version,
+		Locale:   locale,
 		Logger:   logger,
 	}
 
@@ -92,6 +105,11 @@ Usage:
   wolt-mcp              Run the MCP server over stdio.
   wolt-mcp --version    Print version and exit.
   wolt-mcp --help       Print this message and exit.
+  wolt-mcp --locale     Print the active locale and exit.
+
+Options:
+  --locale <bcp47>      Response locale in BCP-47 format (default: en-FI).
+                        Can also be set via the WOLT_LOCALE environment variable.
 
 Wire into an MCP client (Claude Desktop, Claude Code, Cursor) with:
 
@@ -112,4 +130,15 @@ func resolveWoltRequestMinInterval() time.Duration {
 		return defaultWoltHTTPMinInterval
 	}
 	return time.Duration(ms) * time.Millisecond
+}
+
+func resolveLocale() string {
+	if len(os.Args) > 2 && os.Args[1] == "--locale" {
+		return strings.TrimSpace(os.Args[2])
+	}
+	raw := strings.TrimSpace(os.Getenv(localeEnv))
+	if raw != "" {
+		return raw
+	}
+	return defaultLocale
 }

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -209,6 +209,22 @@ higher on slow networks:
 }
 ```
 
+### Locale
+
+The MCP server defaults to `en-FI`. Change it with `--locale` or the
+`WOLT_LOCALE` environment variable:
+
+```json
+{
+  "mcpServers": {
+    "wolt": {
+      "command": "wolt-mcp",
+      "args": ["--locale", "fi-FI"]
+    }
+  }
+}
+```
+
 ## Implementation notes
 
 - Built on `github.com/modelcontextprotocol/go-sdk` v1.6.0 (official Anthropic SDK).

--- a/internal/cli/commands_cart.go
+++ b/internal/cli/commands_cart.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/mekedron/wolt-cli/internal/domain"
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
 	"github.com/mekedron/wolt-cli/internal/service/output"
 	"github.com/spf13/cobra"
@@ -200,7 +201,7 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 					slugForLookup,
 					venueID,
 					nameQuery,
-					resolveAssortmentLanguage(flags.Locale),
+					domain.ResolveAssortmentLanguage(flags.Locale),
 					auth,
 				)
 				if lookupErr != nil {

--- a/internal/cli/commands_venue_item.go
+++ b/internal/cli/commands_venue_item.go
@@ -302,7 +302,7 @@ func newVenueMenuCommand(deps Dependencies) *cobra.Command {
 					deps,
 					slug,
 					strings.TrimSpace(query),
-					resolveAssortmentLanguage(flags.Locale),
+					domain.ResolveAssortmentLanguage(flags.Locale),
 					auth,
 				)
 				if err != nil {
@@ -407,7 +407,7 @@ func newVenueMenuCommand(deps Dependencies) *cobra.Command {
 					deps,
 					slug,
 					categorySlug,
-					resolveAssortmentLanguage(flags.Locale),
+					domain.ResolveAssortmentLanguage(flags.Locale),
 					auth,
 				)
 				if err != nil {
@@ -438,7 +438,7 @@ func newVenueMenuCommand(deps Dependencies) *cobra.Command {
 						cmd.Context(),
 						deps,
 						slug,
-						resolveAssortmentLanguage(flags.Locale),
+						domain.ResolveAssortmentLanguage(flags.Locale),
 						auth,
 						assortmentPayload,
 						derefPositiveInt(limitPtr),
@@ -531,17 +531,6 @@ func derefPositiveInt(value *int) int {
 
 func isAssortmentPartial(payload map[string]any) bool {
 	return strings.EqualFold(strings.TrimSpace(asString(payload["loading_strategy"])), "partial")
-}
-
-func resolveAssortmentLanguage(locale string) string {
-	language := strings.TrimSpace(locale)
-	if idx := strings.Index(language, "-"); idx >= 0 {
-		language = strings.TrimSpace(language[:idx])
-	}
-	if language == "" {
-		return "en"
-	}
-	return language
 }
 
 func newVenueHoursCommand(deps Dependencies) *cobra.Command {

--- a/internal/domain/locale.go
+++ b/internal/domain/locale.go
@@ -1,0 +1,17 @@
+package domain
+
+import "strings"
+
+// ResolveAssortmentLanguage converts a BCP-47 locale (e.g. "en-FI") into a
+// bare language code ("en") suitable for Wolt's assortment language query
+// parameter. Falls back to "en" when the input is empty.
+func ResolveAssortmentLanguage(locale string) string {
+	language := strings.TrimSpace(locale)
+	if idx := strings.Index(language, "-"); idx >= 0 {
+		language = strings.TrimSpace(language[:idx])
+	}
+	if language == "" {
+		return "en"
+	}
+	return language
+}

--- a/internal/mcpserver/context.go
+++ b/internal/mcpserver/context.go
@@ -33,6 +33,7 @@ type Deps struct {
 	Location LocationResolver
 	Config   ConfigStore
 	Version  string
+	Locale   string
 	Logger   *slog.Logger
 }
 
@@ -45,6 +46,7 @@ type ToolCtx struct {
 	location LocationResolver
 	config   ConfigStore
 	version  string
+	locale   string
 	logger   *slog.Logger
 }
 
@@ -59,6 +61,7 @@ func newToolCtx(deps Deps) *ToolCtx {
 		location: deps.Location,
 		config:   deps.Config,
 		version:  deps.Version,
+		locale:   deps.Locale,
 		logger:   logger,
 	}
 }

--- a/internal/mcpserver/tools_venue.go
+++ b/internal/mcpserver/tools_venue.go
@@ -227,7 +227,7 @@ func (tc *ToolCtx) handleVenueSearchItems(ctx context.Context, _ *mcp.CallToolRe
 	if strings.TrimSpace(in.Query) == "" {
 		return nil, VenueSearchItemsOutput{}, toolErrf("query is required")
 	}
-	language := "en"
+	language := resolveAssortmentLanguage(tc.locale)
 	payload, err := tc.wolt.AssortmentItemsSearchByVenueSlug(ctx, firstNonEmpty(ref.Slug, in.Venue), in.Query, language, tc.optionalAuth(ctx))
 	if err != nil {
 		return nil, VenueSearchItemsOutput{}, toolErr(err)
@@ -290,4 +290,15 @@ func filterMenuItemsByName(data map[string]any, needle string) {
 		}
 	}
 	data["items"] = filtered
+}
+
+func resolveAssortmentLanguage(locale string) string {
+	language := strings.TrimSpace(locale)
+	if idx := strings.Index(language, "-"); idx >= 0 {
+		language = strings.TrimSpace(language[:idx])
+	}
+	if language == "" {
+		return "en"
+	}
+	return language
 }

--- a/internal/mcpserver/tools_venue.go
+++ b/internal/mcpserver/tools_venue.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/mekedron/wolt-cli/internal/domain"
 	"github.com/mekedron/wolt-cli/internal/service/observability"
 )
 
@@ -227,7 +228,7 @@ func (tc *ToolCtx) handleVenueSearchItems(ctx context.Context, _ *mcp.CallToolRe
 	if strings.TrimSpace(in.Query) == "" {
 		return nil, VenueSearchItemsOutput{}, toolErrf("query is required")
 	}
-	language := resolveAssortmentLanguage(tc.locale)
+	language := domain.ResolveAssortmentLanguage(tc.locale)
 	payload, err := tc.wolt.AssortmentItemsSearchByVenueSlug(ctx, firstNonEmpty(ref.Slug, in.Venue), in.Query, language, tc.optionalAuth(ctx))
 	if err != nil {
 		return nil, VenueSearchItemsOutput{}, toolErr(err)
@@ -290,15 +291,4 @@ func filterMenuItemsByName(data map[string]any, needle string) {
 		}
 	}
 	data["items"] = filtered
-}
-
-func resolveAssortmentLanguage(locale string) string {
-	language := strings.TrimSpace(locale)
-	if idx := strings.Index(language, "-"); idx >= 0 {
-		language = strings.TrimSpace(language[:idx])
-	}
-	if language == "" {
-		return "en"
-	}
-	return language
 }


### PR DESCRIPTION
This PR adds locale configuration to the MCP server, mirroring the existing CLI `--locale` support.

## What's new

- **`--locale <bcp47>`** CLI flag (e.g. `wolt-mcp --locale fi-FI`)
- **`WOLT_LOCALE`** environment variable fallback
- Default remains **`en-FI`** (matching the CLI)

## How it flows

1. `resolveLocale()` in `cmd/wolt-mcp/main.go` picks up the flag/env value.
2. The locale is wired through `mcpserver.Deps` and `ToolCtx` so every tool handler can access it.
3. `wolt_venue_search_items` now calls `domain.ResolveAssortmentLanguage(tc.locale)` instead of the hardcoded `"en"`.
4. The Wolt gateway client is constructed with `WithLocale(locale)` so the `app-language` header and `language` query parameter use the configured locale.

## Refactoring

- Extracted `resolveAssortmentLanguage` from both `internal/cli` and `internal/mcpserver` into a single exported function in `internal/domain/locale.go` to avoid duplication.

## Documentation

Updated `docs/mcp.md` with the new flag/env examples.
