### PR TITLE
fix(ci): make dependabot auto-merge actually merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,7 +19,8 @@ jobs:
       github.event.workflow_run.pull_requests[0].number != null
     runs-on: ubuntu-latest
     steps:
-      - name: Verify required CI workflows are successful
+      - name: Verify all relevant CI workflows are successful
+        id: check
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
@@ -29,31 +30,49 @@ jobs:
           runs_json="$(gh api \
             "repos/${GITHUB_REPOSITORY}/actions/runs?event=pull_request&head_sha=${HEAD_SHA}&per_page=100")"
 
-          required_workflows=("Go CI" "Docs CI")
-          for workflow_name in "${required_workflows[@]}"; do
-            status="$(echo "${runs_json}" | jq -r --arg wf "${workflow_name}" \
-              '.workflow_runs[] | select(.name == $wf) | .status' | head -n1)"
+          # Each workflow is treated as required only if it actually ran for this
+          # SHA. Path filters on Docs CI / Go CI mean a Go-only or docs-only PR
+          # legitimately runs just one of them; the other should not block merge.
+          candidate_workflows=("Go CI" "Docs CI")
+          ran_at_least_one=false
+
+          for workflow_name in "${candidate_workflows[@]}"; do
             conclusion="$(echo "${runs_json}" | jq -r --arg wf "${workflow_name}" \
-              '.workflow_runs[] | select(.name == $wf) | .conclusion' | head -n1)"
+              '[.workflow_runs[] | select(.name == $wf)] | (.[0].conclusion // "missing")')"
 
-            if [ -z "${status}" ]; then
-              echo "Workflow '${workflow_name}' has not run yet for ${HEAD_SHA}. Skipping."
-              exit 0
-            fi
-
-            if [ "${conclusion}" != "success" ]; then
-              echo "Workflow '${workflow_name}' conclusion='${conclusion}'. Skipping."
-              exit 0
-            fi
+            case "${conclusion}" in
+              missing|skipped)
+                echo "Workflow '${workflow_name}' did not run for ${HEAD_SHA} (likely path filter). Treating as N/A."
+                ;;
+              success)
+                echo "Workflow '${workflow_name}' succeeded."
+                ran_at_least_one=true
+                ;;
+              *)
+                echo "Workflow '${workflow_name}' conclusion='${conclusion}'. Not auto-merging."
+                echo "proceed=false" >> "${GITHUB_OUTPUT}"
+                exit 0
+                ;;
+            esac
           done
 
+          if [ "${ran_at_least_one}" != "true" ]; then
+            echo "No required workflow ran successfully for ${HEAD_SHA}. Refusing to auto-merge."
+            echo "proceed=false" >> "${GITHUB_OUTPUT}"
+            exit 0
+          fi
+
+          echo "proceed=true" >> "${GITHUB_OUTPUT}"
+
       - name: Auto-approve pull request
+        if: steps.check.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}
-        run: gh pr review --repo "${GITHUB_REPOSITORY}" "${PR_NUMBER}" --approve --body "Auto-approved after successful Go CI and Docs CI."
+        run: gh pr review --repo "${GITHUB_REPOSITORY}" "${PR_NUMBER}" --approve --body "Auto-approved after successful CI."
 
       - name: Enable auto-merge
+        if: steps.check.outputs.proceed == 'true'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.workflow_run.pull_requests[0].number }}


### PR DESCRIPTION
## Summary
- Adds a `proceed` output to the verify step and `if:` guards on the approve/merge steps, so we don't try to approve/merge after the verify step bailed out.
- Treats a required workflow that didn't run for the head SHA (path filter) as N/A instead of as a blocker, while still refusing to merge when nothing relevant succeeded.
- Trims the approval body to "Auto-approved after successful CI." since we no longer hardcode workflow names.

## Why
Recent runs were either silently failing at `gh pr review --approve` ("GitHub Actions is not permitted to approve pull requests") or skipping in a way that didn't actually stop the next step. Concretely, PR #8 (Go-only) and PR #4 (actions-only) couldn't be auto-merged because Docs CI never ran for them, and the static "both workflows required" check would have skipped — except the skip didn't gate the merge step.

## Repo setting still required
This fix is necessary but not sufficient. Repo currently has
\`\`\`
"can_approve_pull_request_reviews": false
\`\`\`
which blocks `gh pr review --approve` from a GitHub-Actions token regardless of workflow logic. Enable
**Settings → Actions → General → "Allow GitHub Actions to create and approve pull requests"**
before expecting auto-merge to actually work end-to-end.

## Test plan
- [ ] Go CI is green on this PR
- [ ] CodeQL is green
- [ ] After merge, the next dependabot PR is auto-approved and auto-merged once CI is green (assuming the repo setting above is also enabled)