### PR TITLE
fix current item availability, images, and currency

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -288,6 +288,12 @@ resolved (an unknown slug, or one Wolt no longer serves) `cart add`
 fails with `WOLT_VENUE_UNRESOLVED` instead of reporting a success that
 never reaches your cart.
 
+It then refreshes the exact current item. A non-null `disabled_info`,
+zero `purchasable_balance`, or a missing current item blocks the mutation
+even when `--price`, `--currency`, and `--name` are supplied. Currency is
+resolved from current item, basket, or venue metadata; the command fails
+instead of silently defaulting to EUR.
+
 `--option` accepts both IDs and case-insensitive names:
 
 ```console

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -116,9 +116,9 @@ persists the rotated tokens, and retries the original call once.
 | Tool | What it does |
 |---|---|
 | `wolt_venue_detail` ✓ | Address, rating, delivery methods, opening windows, tags |
-| `wolt_venue_menu` ✓ | Browse a venue's menu (paginated, filterable) |
+| `wolt_venue_menu` ✓ | Browse a venue's menu with image URLs and current availability (paginated, filterable) |
 | `wolt_venue_hours` ✓ | Opening windows in the venue's timezone |
-| `wolt_venue_item` ✓ | Full payload for one item (price, options, sold-out) |
+| `wolt_venue_item` ✓ | Current item payload (price, options, image URLs, availability) |
 | `wolt_venue_search_items` ✓ | Free-text item search within a venue |
 
 ### Account (auth required)
@@ -152,6 +152,12 @@ persists the rotated tokens, and retries the original call once.
 
 > **Note:** No tool places an actual order. Final checkout still happens in the
 > official Wolt app or web UI. `wolt_checkout_preview` is a pricing preview only.
+
+`wolt_cart_add` always revalidates the exact item before mutating the basket;
+caller-supplied display metadata cannot bypass an unavailable item.
+`wolt_checkout_preview` revalidates every basket item before sending the
+preview request. Both operations fail closed if availability or venue
+currency cannot be verified.
 
 ## Location precedence
 

--- a/docs/output-contract.md
+++ b/docs/output-contract.md
@@ -253,7 +253,11 @@ count, total, offset, limit, total_pages, next_offset, page
 ```
 venue_id, wolt_plus
 categories[]
-items[]: { item_id, name, base_price, discounts }
+items[]: {
+  item_id, name, base_price, discounts,
+  is_available, unavailable_reason, purchasable_balance,
+  image_url, image_urls
+}
 
 # Optional
 items[].original_price          (campaign-adjusted)
@@ -265,7 +269,11 @@ count, offset, limit, total_pages, next_offset, page, sort
 
 ```
 venue_id, venue_slug, query, total
-items[]: { item_id, name, category, base_price, discounts, is_sold_out }
+items[]: {
+  item_id, name, category, base_price, discounts,
+  is_available, unavailable_reason, purchasable_balance,
+  image_url, image_urls
+}
 
 # Optional
 items[].original_price          (upstream pre-discount amount)
@@ -276,6 +284,11 @@ count, offset, limit, total_pages, next_offset, page, sort
 When upstream omits the currency, it is normalized from venue metadata.
 When `original_price` is present without a promo label, the CLI derives
 a synthetic discount (e.g. `21% off`).
+
+Availability is derived from Wolt's current `disabled_info` and
+`purchasable_balance` fields. `is_sold_out` remains as a deprecated,
+derived compatibility alias (`!is_available`); raw `is_sold_out` and
+`sold_out` fields are not expected from Wolt.
 
 ### `wolt venue hours <slug>` — VenueHours
 
@@ -289,12 +302,16 @@ opening_windows[]
 
 ```
 item_id, venue_id, name, description, price
+is_available, unavailable_reason, purchasable_balance
+image_url, image_urls, image_blurhash
 option_groups[]
 upsell_items[]
 ```
 
 `price.formatted_amount` is normalized from venue metadata when upstream
 omits the currency. `upsell_items[].price` follows the same rule.
+The exact current-item response is merged with the item page so current image
+and availability metadata are preserved alongside option groups.
 
 ### `wolt cart` — CartState
 
@@ -321,6 +338,11 @@ remove: basket_id, venue_id, line_id, removed_count
 clear:  basket_ids[], cleared_baskets
 ```
 
+Before `cart add`, the CLI always fetches the exact current item and refuses
+the mutation when it is disabled, has zero purchasable balance, is missing
+from the current assortment, or cannot be validated. Explicit `--price`,
+`--currency`, and `--name` values do not bypass this check.
+
 ### `wolt checkout` — CheckoutPreview
 
 ```
@@ -334,6 +356,9 @@ tip_config
 ```
 
 Preview-only. The CLI never calls the order placement endpoint.
+Every basket item is revalidated through the exact current-item endpoint
+before preview. Currency comes from structured item, basket, or venue metadata
+(including GEL); there is no implicit EUR fallback.
 
 ### `wolt stats` — StatsLaunch
 

--- a/internal/cli/cart_helpers.go
+++ b/internal/cli/cart_helpers.go
@@ -149,7 +149,7 @@ func buildItemPayloadFromAssortment(assortment map[string]any, itemID string) ma
 		asMap(assortment["venue"])["currency"],
 	)))
 	if currency == "" {
-		currency = "EUR"
+		currency = payloadutil.CurrencyFromVenuePayload(assortment)
 	}
 
 	optionGroupIDs := extractAssortmentOptionGroupIDs(item)
@@ -179,7 +179,17 @@ func buildItemPayloadFromAssortment(assortment map[string]any, itemID string) ma
 		"amount":   priceAmount,
 		"currency": currency,
 	}
-	return map[string]any{
+	itemRow := map[string]any{
+		"id":            targetItemID,
+		"item_id":       targetItemID,
+		"name":          item["name"],
+		"description":   coalesceAny(item["description"], ""),
+		"price":         price,
+		"base_price":    price,
+		"option_groups": optionGroups,
+		"options":       optionGroups,
+	}
+	result := map[string]any{
 		"item_id":       targetItemID,
 		"id":            targetItemID,
 		"name":          item["name"],
@@ -188,19 +198,23 @@ func buildItemPayloadFromAssortment(assortment map[string]any, itemID string) ma
 		"base_price":    price,
 		"option_groups": optionGroups,
 		"options":       optionGroups,
-		"items": []any{
-			map[string]any{
-				"id":            targetItemID,
-				"item_id":       targetItemID,
-				"name":          item["name"],
-				"description":   coalesceAny(item["description"], ""),
-				"price":         price,
-				"base_price":    price,
-				"option_groups": optionGroups,
-				"options":       optionGroups,
-			},
-		},
+		"items":         []any{itemRow},
 	}
+	for _, key := range []string{
+		"images",
+		"disabled_info",
+		"purchasable_balance",
+		"unit_info",
+		"unit_price",
+		"sell_by_weight_config",
+		"available_times",
+	} {
+		if value, exists := item[key]; exists {
+			result[key] = value
+			itemRow[key] = value
+		}
+	}
+	return result
 }
 
 func extractAssortmentOptionGroupIDs(item map[string]any) []string {

--- a/internal/cli/cart_helpers_test.go
+++ b/internal/cli/cart_helpers_test.go
@@ -104,6 +104,7 @@ func TestBuildItemPayloadFromAssortment(t *testing.T) {
 
 func TestBuildItemPayloadFromMenuPayload(t *testing.T) {
 	payload := map[string]any{
+		"venue": map[string]any{"currency": "GEL"},
 		"sections": []any{
 			map[string]any{
 				"name": "Deals",
@@ -139,8 +140,8 @@ func TestBuildItemPayloadFromMenuPayload(t *testing.T) {
 	if asInt(asMap(itemPayload["price"])["amount"]) != 299 {
 		t.Fatalf("expected item price 299, got %v", asMap(itemPayload["price"])["amount"])
 	}
-	if asString(asMap(itemPayload["price"])["currency"]) != "EUR" {
-		t.Fatalf("expected fallback currency EUR, got %v", asMap(itemPayload["price"])["currency"])
+	if asString(asMap(itemPayload["price"])["currency"]) != "GEL" {
+		t.Fatalf("expected venue currency GEL, got %v", asMap(itemPayload["price"])["currency"])
 	}
 	groups := asSlice(itemPayload["option_groups"])
 	if len(groups) != 1 {

--- a/internal/cli/commands_cart.go
+++ b/internal/cli/commands_cart.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/mekedron/wolt-cli/internal/domain"
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/output"
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
 	"github.com/spf13/cobra"
 )
 
@@ -264,25 +266,98 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 			}
 
 			warnings := []string{}
+			slugCandidates := []string{}
+			if overrideSlug := strings.TrimSpace(venueSlug); overrideSlug != "" {
+				slugCandidates = append(slugCandidates, overrideSlug)
+			}
+			if ref := strings.TrimSpace(venueArg); ref != "" && !looksLikeObjectID(ref) {
+				slugCandidates = append(slugCandidates, normalizeVenueInput(ref))
+			}
+			if restaurant, restaurantErr := deps.Wolt.RestaurantByID(cmd.Context(), venueID); restaurantErr == nil && restaurant != nil {
+				if restaurantSlug := strings.TrimSpace(restaurant.Slug); restaurantSlug != "" {
+					slugCandidates = append(slugCandidates, restaurantSlug)
+				}
+			}
+			slugCandidates = dedupeStrings(slugCandidates)
+			if len(slugCandidates) == 0 {
+				return emitError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_ITEM_AVAILABILITY_UNKNOWN",
+					"Unable to resolve the venue slug, so current item availability could not be verified. Pass the venue slug or a Wolt venue/item URL.",
+				)
+			}
+
+			currentAssortmentPayload := map[string]any{}
+			availabilityLookupSucceeded := false
+			for _, candidateSlug := range slugCandidates {
+				payload, availabilityWarnings, availabilityErr := invokeWithAuthAutoRefresh(
+					cmd.Context(),
+					deps,
+					flags,
+					&auth,
+					func(authCtx woltgateway.AuthContext) (map[string]any, error) {
+						return deps.Wolt.AssortmentItemsByVenueSlug(
+							cmd.Context(),
+							candidateSlug,
+							[]string{itemID},
+							authCtx,
+						)
+					},
+				)
+				warnings = append(warnings, availabilityWarnings...)
+				if availabilityErr != nil {
+					warnings = append(warnings, fmt.Sprintf("availability lookup failed for venue slug %s", candidateSlug))
+					continue
+				}
+				availabilityLookupSucceeded = true
+				if catalogitem.Find(payload, itemID) == nil {
+					continue
+				}
+				currentAssortmentPayload = payload
+				venueSlug = candidateSlug
+				break
+			}
+			if !availabilityLookupSucceeded {
+				return emitErrorWithWarnings(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_ITEM_AVAILABILITY_UNKNOWN",
+					"Item was not added because current availability could not be verified.",
+					warnings,
+				)
+			}
+			availabilityIssues := catalogitem.ValidateItemIDs(currentAssortmentPayload, []string{itemID})
+			if len(availabilityIssues) > 0 {
+				return emitErrorWithWarnings(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_ITEM_UNAVAILABLE",
+					"Item was not added because current availability validation failed: "+
+						catalogitem.FormatValidationIssues(availabilityIssues),
+					warnings,
+				)
+			}
+
 			itemPayload := map[string]any{}
 			if payload, itemErr := deps.Wolt.VenueItemPage(cmd.Context(), venueID, itemID); itemErr == nil {
 				itemPayload = payload
 			} else {
 				warnings = append(warnings, "item endpoint unavailable")
 			}
+			if fallback := buildItemPayloadFromAssortment(currentAssortmentPayload, itemID); fallback != nil {
+				itemPayload = mergeItemPayloadFallback(itemPayload, fallback)
+			}
 			if needsAssortmentFallback(itemPayload) {
-				slugCandidates := []string{}
-				if overrideSlug := strings.TrimSpace(venueSlug); overrideSlug != "" {
-					slugCandidates = append(slugCandidates, overrideSlug)
-				}
-				if ref := strings.TrimSpace(venueID); ref != "" && !looksLikeObjectID(ref) {
-					slugCandidates = append(slugCandidates, ref)
-				}
-				if restaurant, err := deps.Wolt.RestaurantByID(cmd.Context(), venueID); err == nil && restaurant != nil {
-					if restaurantSlug := strings.TrimSpace(restaurant.Slug); restaurantSlug != "" {
-						slugCandidates = append(slugCandidates, restaurantSlug)
-					}
-				}
 				for _, candidateSlug := range dedupeStrings(slugCandidates) {
 					assortmentPayload := map[string]any{}
 					if payload, err := deps.Wolt.AssortmentByVenueSlug(cmd.Context(), candidateSlug); err == nil {
@@ -332,12 +407,15 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 				)
 			}
 
-			currency := strings.TrimSpace(currencyOverride)
+			currency := payloadutil.NormalizeCurrency(currencyOverride)
 			if currency == "" {
-				currency = strings.TrimSpace(asString(asMap(itemPayload["price"])["currency"]))
+				currency = currencyFromItemPayload(itemPayload)
 			}
 			if currency == "" {
-				currency = "EUR"
+				currency = payloadutil.CurrencyFromVenuePayload(currentAssortmentPayload)
+			}
+			if currency == "" {
+				currency = currencyFromVenue(cmd.Context(), deps, venueSlug)
 			}
 
 			selectedOptions, err := parseOptionSelections(optionFlags)
@@ -374,6 +452,9 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 			if preAddErr == nil {
 				selectedBasket, _, _ := selectBasketWithMeta(existingPage, venueID)
 				if selectedBasket != nil {
+					if currency == "" {
+						currency = payloadutil.CurrencyFromBasket(selectedBasket)
+					}
 					resolvedVenue := asMap(selectedBasket["venue"])
 					if resolvedVenueID := strings.TrimSpace(asString(resolvedVenue["id"])); resolvedVenueID != "" {
 						venueMutationID = resolvedVenueID
@@ -406,6 +487,17 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 				}
 			} else {
 				warnings = append(warnings, "unable to load existing basket snapshot before add; upstream may replace existing lines")
+			}
+			if currency == "" {
+				return emitError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_CURRENCY_UNKNOWN",
+					"Item was not added because the venue currency could not be verified.",
+				)
 			}
 
 			// Refuse to POST when the venue still hasn't resolved to a real
@@ -674,9 +766,25 @@ func newCartRemoveCommand(deps Dependencies) *cobra.Command {
 			basketID := asString(selected["id"])
 			venue := asMap(selected["venue"])
 			venueResolvedID := asString(venue["id"])
-			currency := inferCurrency(asString(selected["total"]))
+			currency := payloadutil.CurrencyFromBasket(selected)
 			if currency == "" {
-				currency = "EUR"
+				currency = currencyFromVenue(cmd.Context(), deps, asString(coalesceAny(
+					venue["slug"],
+					venue["venue_slug"],
+					venue["public_slug"],
+					venue["url_slug"],
+				)))
+			}
+			if currency == "" && nextCount > 0 {
+				return emitError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_CURRENCY_UNKNOWN",
+					"Item quantity was not changed because the venue currency could not be verified.",
+				)
 			}
 
 			mutation := "remove"
@@ -900,7 +1008,7 @@ func newCartClearCommand(deps Dependencies) *cobra.Command {
 				"total_items":     0,
 				"total": map[string]any{
 					"amount":           0,
-					"formatted_amount": formatMinorAmount(0, "EUR"),
+					"formatted_amount": nil,
 				},
 			}
 			warnings = append(warnings, authWarnings...)
@@ -1003,7 +1111,7 @@ func buildCartState(page map[string]any, venueID string) (map[string]any, []stri
 
 	venue := asMap(selected["venue"])
 	totalFormatted := asString(selected["total"])
-	currency := inferCurrency(totalFormatted)
+	currency := payloadutil.CurrencyFromBasket(selected)
 	items := asSlice(selected["items"])
 	lines := make([]any, 0, len(items))
 	subtotalAmount := 0

--- a/internal/cli/commands_cart.go
+++ b/internal/cli/commands_cart.go
@@ -300,8 +300,9 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 					flags,
 					&auth,
 					func(authCtx woltgateway.AuthContext) (map[string]any, error) {
-						return deps.Wolt.AssortmentItemsByVenueSlug(
+						return requestAssortmentItemsPayload(
 							cmd.Context(),
+							deps,
 							candidateSlug,
 							[]string{itemID},
 							authCtx,

--- a/internal/cli/commands_checkout.go
+++ b/internal/cli/commands_checkout.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/checkoutpayload"
 	"github.com/mekedron/wolt-cli/internal/service/output"
 	"github.com/spf13/cobra"
@@ -97,6 +98,75 @@ func newCheckoutPreviewCommand(deps Dependencies) *cobra.Command {
 					"No basket found for checkout preview.",
 				)
 			}
+			basketVenue := asMap(basket["venue"])
+			venueSlug := strings.TrimSpace(asString(coalesceAny(
+				basketVenue["slug"],
+				basketVenue["venue_slug"],
+				basketVenue["public_slug"],
+				basketVenue["url_slug"],
+			)))
+			if venueSlug == "" && strings.TrimSpace(venueID) != "" && !looksLikeObjectID(venueID) {
+				venueSlug = normalizeVenueInput(venueID)
+			}
+			if venueSlug == "" {
+				basketVenueID := strings.TrimSpace(asString(basketVenue["id"]))
+				if restaurant, restaurantErr := deps.Wolt.RestaurantByID(cmd.Context(), basketVenueID); restaurantErr == nil && restaurant != nil {
+					venueSlug = strings.TrimSpace(restaurant.Slug)
+				}
+			}
+			if venueSlug == "" {
+				return emitError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_ITEM_AVAILABILITY_UNKNOWN",
+					"Checkout was not previewed because the venue slug could not be resolved for current item validation.",
+				)
+			}
+			if basketVenue == nil {
+				basketVenue = map[string]any{}
+				basket["venue"] = basketVenue
+			}
+			basketVenue["slug"] = venueSlug
+
+			basketItemIDs := catalogitem.BasketItemIDs(basket)
+			currentItems, validationWarnings, validationErr := invokeWithAuthAutoRefresh(
+				cmd.Context(),
+				deps,
+				flags,
+				&auth,
+				func(authCtx woltgateway.AuthContext) (map[string]any, error) {
+					return deps.Wolt.AssortmentItemsByVenueSlug(cmd.Context(), venueSlug, basketItemIDs, authCtx)
+				},
+			)
+			if validationErr != nil {
+				return emitUpstreamError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					flags.Verbose,
+					validationErr,
+					validationWarnings...,
+				)
+			}
+			availabilityIssues := catalogitem.ValidateItemIDs(currentItems, basketItemIDs)
+			if len(availabilityIssues) > 0 {
+				return emitErrorWithWarnings(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_CART_ITEMS_UNAVAILABLE",
+					"Checkout was not previewed because the basket contains unavailable items: "+
+						catalogitem.FormatValidationIssues(availabilityIssues),
+					validationWarnings,
+				)
+			}
 
 			checkoutPayload, checkoutWarnings, err := checkoutpayload.Build(
 				cmd.Context(),
@@ -141,7 +211,9 @@ func newCheckoutPreviewCommand(deps Dependencies) *cobra.Command {
 				payableFormatted = findTotalFormattedAmount(payload)
 			}
 			if payableFormatted == "" {
-				payableFormatted = formatMinorAmount(payableAmount, inferCurrency(asString(asMap(basket)["total"])))
+				purchasePlan := asMap(checkoutPayload["purchase_plan"])
+				purchaseVenue := asMap(purchasePlan["venue"])
+				payableFormatted = formatMinorAmount(payableAmount, asString(purchaseVenue["currency"]))
 			}
 			data := map[string]any{
 				"basket_id":  asString(basket["id"]),

--- a/internal/cli/commands_checkout.go
+++ b/internal/cli/commands_checkout.go
@@ -138,7 +138,13 @@ func newCheckoutPreviewCommand(deps Dependencies) *cobra.Command {
 				flags,
 				&auth,
 				func(authCtx woltgateway.AuthContext) (map[string]any, error) {
-					return deps.Wolt.AssortmentItemsByVenueSlug(cmd.Context(), venueSlug, basketItemIDs, authCtx)
+					return requestAssortmentItemsPayload(
+						cmd.Context(),
+						deps,
+						venueSlug,
+						basketItemIDs,
+						authCtx,
+					)
 				},
 			)
 			if validationErr != nil {

--- a/internal/cli/commands_venue_item.go
+++ b/internal/cli/commands_venue_item.go
@@ -1081,7 +1081,7 @@ func resolveVenueItemPayloadBySlug(
 	} else {
 		warnings = append(warnings, "venue assortment endpoint unavailable")
 	}
-	if payload, err := deps.Wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, []string{itemID}, auth); err == nil {
+	if payload, err := requestAssortmentItemsPayload(ctx, deps, venueSlug, []string{itemID}, auth); err == nil {
 		currentItem = catalogitem.Find(payload, itemID)
 	} else {
 		warnings = append(warnings, "current item endpoint unavailable")

--- a/internal/cli/commands_venue_item.go
+++ b/internal/cli/commands_venue_item.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/mekedron/wolt-cli/internal/domain"
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/observability"
 	"github.com/mekedron/wolt-cli/internal/service/output"
 	"github.com/spf13/cobra"
@@ -1057,6 +1058,7 @@ func resolveVenueItemPayloadBySlug(
 	assortmentPayload := map[string]any{}
 	venueContentPayloads := []map[string]any{}
 	venueContentLoaded := false
+	currentItem := map[string]any{}
 	loadVenueContent := func() {
 		if venueContentLoaded {
 			return
@@ -1079,6 +1081,11 @@ func resolveVenueItemPayloadBySlug(
 	} else {
 		warnings = append(warnings, "venue assortment endpoint unavailable")
 	}
+	if payload, err := deps.Wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, []string{itemID}, auth); err == nil {
+		currentItem = catalogitem.Find(payload, itemID)
+	} else {
+		warnings = append(warnings, "current item endpoint unavailable")
+	}
 	if needsVenueContentFallback(assortmentPayload, venueID) {
 		loadVenueContent()
 	}
@@ -1087,6 +1094,9 @@ func resolveVenueItemPayloadBySlug(
 	if venueID != "" {
 		if itemPayload, err := deps.Wolt.VenueItemPage(ctx, venueID, itemID); err == nil {
 			payload = itemPayload
+			if len(currentItem) > 0 {
+				payload = catalogitem.MergeCurrentItem(payload, currentItem)
+			}
 			if fallback := buildItemPayloadFromAssortment(assortmentPayload, itemID); fallback != nil {
 				payload = mergeItemPayloadFallback(payload, fallback)
 			}
@@ -1100,6 +1110,9 @@ func resolveVenueItemPayloadBySlug(
 			warnings = append(warnings, "item endpoint unavailable")
 			if fallback := buildItemPayloadFromAssortment(assortmentPayload, itemID); fallback != nil {
 				payload = fallback
+			}
+			if len(currentItem) > 0 {
+				payload = catalogitem.MergeCurrentItem(payload, currentItem)
 			}
 			if !payloadContainsItem(payload, venueID, itemID) {
 				if len(venueContentPayloads) == 0 {
@@ -1117,6 +1130,14 @@ func resolveVenueItemPayloadBySlug(
 	}
 	if len(payload) == 0 && len(assortmentPayload) > 0 {
 		payload = assortmentPayload
+	}
+	if len(currentItem) > 0 {
+		payload = catalogitem.MergeCurrentItem(payload, currentItem)
+	}
+	if len(payload) > 0 {
+		if currency := currencyFromVenue(ctx, deps, venueSlug); currency != "" {
+			payload["currency"] = currency
+		}
 	}
 	if len(payload) == 0 {
 		warnings = append(warnings, "item payload fallback unavailable")

--- a/internal/cli/currency_helpers.go
+++ b/internal/cli/currency_helpers.go
@@ -1,0 +1,38 @@
+package cli
+
+import (
+	"context"
+	"strings"
+
+	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
+)
+
+func currencyFromItemPayload(payload map[string]any) string {
+	for _, candidate := range []any{
+		payload["currency"],
+		asMap(payload["price"])["currency"],
+		asMap(payload["base_price"])["currency"],
+	} {
+		if currency := payloadutil.NormalizeCurrency(asString(candidate)); currency != "" {
+			return currency
+		}
+	}
+	return ""
+}
+
+func currencyFromVenue(ctx context.Context, deps Dependencies, slug string) string {
+	slug = strings.TrimSpace(slug)
+	if slug == "" || deps.Wolt == nil {
+		return ""
+	}
+	if payload, err := cachedVenuePageStatic(ctx, deps, slug); err == nil {
+		if currency := payloadutil.CurrencyFromVenuePayload(payload); currency != "" {
+			return currency
+		}
+	}
+	if payload, err := deps.Wolt.VenuePageDynamic(ctx, slug, woltgateway.VenuePageDynamicOptions{}); err == nil {
+		return payloadutil.CurrencyFromVenuePayload(payload)
+	}
+	return ""
+}

--- a/internal/cli/row_filters.go
+++ b/internal/cli/row_filters.go
@@ -65,7 +65,9 @@ func applyItemRowFilters(rows []any, filters itemRowFilters) []any {
 		if row == nil {
 			continue
 		}
-		if filters.HideSoldOut && asBool(row["is_sold_out"]) {
+		available, hasAvailability := row["is_available"]
+		if filters.HideSoldOut &&
+			((hasAvailability && !asBool(available)) || (!hasAvailability && asBool(row["is_sold_out"]))) {
 			continue
 		}
 		if filters.DiscountsOnly && !itemHasDiscount(row) {

--- a/internal/cli/test_mocks_test.go
+++ b/internal/cli/test_mocks_test.go
@@ -14,6 +14,7 @@ type testWoltAPI struct {
 	venuePageStaticFn    func(context.Context, string) (map[string]any, error)
 	venuePageDynamicFn   func(context.Context, string, woltgateway.VenuePageDynamicOptions) (map[string]any, error)
 	assortmentBySlugFn   func(context.Context, string) (map[string]any, error)
+	assortmentItemsFn    func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error)
 }
 
 func (m *testWoltAPI) FrontPage(context.Context, domain.Location) (map[string]any, error) {
@@ -64,8 +65,11 @@ func (m *testWoltAPI) AssortmentCategoryByVenueSlug(context.Context, string, str
 	return map[string]any{}, nil
 }
 
-func (m *testWoltAPI) AssortmentItemsByVenueSlug(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
-	return map[string]any{}, nil
+func (m *testWoltAPI) AssortmentItemsByVenueSlug(ctx context.Context, slug string, itemIDs []string, auth woltgateway.AuthContext) (map[string]any, error) {
+	if m.assortmentItemsFn != nil {
+		return m.assortmentItemsFn(ctx, slug, itemIDs, auth)
+	}
+	return availableTestItems(itemIDs), nil
 }
 
 func (m *testWoltAPI) AssortmentItemsSearchByVenueSlug(context.Context, string, string, string, woltgateway.AuthContext) (map[string]any, error) {
@@ -168,6 +172,18 @@ func (m *testWoltAPI) RefreshAccessToken(ctx context.Context, refreshToken strin
 
 type testProfiles struct {
 	profile domain.Profile
+}
+
+func availableTestItems(itemIDs []string) map[string]any {
+	items := make([]any, 0, len(itemIDs))
+	for _, itemID := range itemIDs {
+		items = append(items, map[string]any{
+			"id":                  itemID,
+			"name":                itemID,
+			"purchasable_balance": 10,
+		})
+	}
+	return map[string]any{"items": items}
 }
 
 func (m *testProfiles) Find(context.Context, string) (domain.Profile, error) {

--- a/internal/cli/venue_content_helpers.go
+++ b/internal/cli/venue_content_helpers.go
@@ -7,6 +7,7 @@ import (
 
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
 	"github.com/mekedron/wolt-cli/internal/service/observability"
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
 )
 
 const defaultVenueContentPageLimit = 3
@@ -99,7 +100,7 @@ func buildItemPayloadFromMenuPayload(payload map[string]any, venueID string, ite
 		currency = inferCurrency(asString(basePrice["formatted_amount"]))
 	}
 	if currency == "" {
-		currency = "EUR"
+		currency = payloadutil.CurrencyFromVenuePayload(payload)
 	}
 
 	price := map[string]any{

--- a/internal/cli/venue_reference.go
+++ b/internal/cli/venue_reference.go
@@ -242,7 +242,8 @@ func selectCheapestMenuItem(items []map[string]any, query string) (cartItemCandi
 	var best cartItemCandidate
 	found := false
 	for _, item := range items {
-		if asBool(item["is_sold_out"]) {
+		if available, exists := item["is_available"]; (exists && !asBool(available)) ||
+			(!exists && asBool(item["is_sold_out"])) {
 			continue
 		}
 		price := asInt(asMap(item["base_price"])["amount"])

--- a/internal/cli/venue_reference_cheapest_test.go
+++ b/internal/cli/venue_reference_cheapest_test.go
@@ -10,12 +10,19 @@ import (
 // menuItem builds a normalized menu row in the shape produced by
 // observability.ExtractMenuItems (and consumed by selectCheapestMenuItem).
 func menuItem(id, name string, price int, soldOut bool) map[string]any {
-	return map[string]any{
-		"item_id":     id,
-		"name":        name,
-		"base_price":  map[string]any{"amount": price, "currency": "EUR"},
-		"is_sold_out": soldOut,
+	item := map[string]any{
+		"item_id":      id,
+		"name":         name,
+		"base_price":   map[string]any{"amount": price, "currency": "EUR"},
+		"is_available": !soldOut,
+		"is_sold_out":  soldOut,
 	}
+	if soldOut {
+		item["disabled_info"] = map[string]any{"disable_text": "Sold out"}
+	} else {
+		item["disabled_info"] = nil
+	}
+	return item
 }
 
 func TestSelectCheapestMenuItem(t *testing.T) {

--- a/internal/mcpserver/assortment.go
+++ b/internal/mcpserver/assortment.go
@@ -1,0 +1,30 @@
+package mcpserver
+
+import (
+	"context"
+
+	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+)
+
+// requestAssortmentItems reads the public exact-item endpoint. Some Wolt
+// markets reject otherwise valid saved credentials on this endpoint while
+// accepting the same request anonymously, so current catalog reads retry
+// without credentials. Basket and checkout mutations remain authenticated.
+func requestAssortmentItems(
+	ctx context.Context,
+	tc *ToolCtx,
+	venueSlug string,
+	itemIDs []string,
+	auth woltgateway.AuthContext,
+) (map[string]any, error) {
+	payload, err := tc.wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, itemIDs, auth)
+	if err == nil || !auth.HasCredentials() {
+		return payload, err
+	}
+	return tc.wolt.AssortmentItemsByVenueSlug(
+		ctx,
+		venueSlug,
+		itemIDs,
+		woltgateway.AuthContext{},
+	)
+}

--- a/internal/mcpserver/currency.go
+++ b/internal/mcpserver/currency.go
@@ -1,0 +1,48 @@
+package mcpserver
+
+import (
+	"context"
+	"strings"
+
+	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
+)
+
+func resolveVenueCurrency(
+	ctx context.Context,
+	tc *ToolCtx,
+	ref venueRef,
+	basket map[string]any,
+	payloads ...map[string]any,
+) string {
+	if currency := payloadutil.CurrencyFromBasket(basket); currency != "" {
+		return currency
+	}
+	for _, payload := range payloads {
+		for _, candidate := range []any{
+			payload["currency"],
+			asMap(payload["price"])["currency"],
+			asMap(payload["base_price"])["currency"],
+		} {
+			if currency := payloadutil.NormalizeCurrency(asString(candidate)); currency != "" {
+				return currency
+			}
+		}
+		if currency := payloadutil.CurrencyFromVenuePayload(payload); currency != "" {
+			return currency
+		}
+	}
+	slug := strings.TrimSpace(ref.Slug)
+	if slug == "" || tc == nil || tc.wolt == nil {
+		return ""
+	}
+	if payload, err := tc.wolt.VenuePageStatic(ctx, slug); err == nil {
+		if currency := payloadutil.CurrencyFromVenuePayload(payload); currency != "" {
+			return currency
+		}
+	}
+	if payload, err := tc.wolt.VenuePageDynamic(ctx, slug, woltgateway.VenuePageDynamicOptions{}); err == nil {
+		return payloadutil.CurrencyFromVenuePayload(payload)
+	}
+	return ""
+}

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -357,6 +357,131 @@ func TestHandleCartAddRejectsUnresolvedVenue(t *testing.T) {
 	}
 }
 
+func TestHandleCartAddBlocksUnavailableItemEvenWithOverrides(t *testing.T) {
+	const venueID = "5f9a1b2c3d4e5f6071829304"
+	const itemID = "627cb2c7e2a6f0a1b2c3d4e5"
+	addCalled := false
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Chicken thigh",
+					"disabled_info":       map[string]any{"disable_text": "Sold out"},
+					"purchasable_balance": 0,
+				},
+			}}, nil
+		},
+		addToBasketFn: func(context.Context, map[string]any, woltgateway.AuthContext) (map[string]any, error) {
+			addCalled = true
+			return map[string]any{}, nil
+		},
+	}
+	tc := newToolCtx(Deps{
+		Wolt:     wolt,
+		Profiles: &stubProfiles{profile: domain.Profile{Name: "default", WToken: "token"}},
+		Location: &stubLocation{},
+		Config:   &stubConfig{},
+	})
+
+	_, _, err := tc.handleCartAdd(context.Background(), nil, CartAddInput{
+		LocationInput: LocationInput{Lat: 41.7, Lon: 44.8},
+		Venue:         "test-venue",
+		ItemID:        itemID,
+		Price:         1645,
+		Currency:      "GEL",
+		Name:          "Chicken thigh",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Sold out") {
+		t.Fatalf("expected Sold out validation error, got %v", err)
+	}
+	if addCalled {
+		t.Fatal("AddToBasket must not be called when the exact current item is unavailable")
+	}
+}
+
+func TestHandleCartAddUsesVenueGELCurrency(t *testing.T) {
+	const venueID = "5f9a1b2c3d4e5f6071829304"
+	const itemID = "627cb2c7e2a6f0a1b2c3d4e5"
+	var captured map[string]any
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Chicken thigh",
+					"price":               1645,
+					"purchasable_balance": 8,
+				},
+			}}, nil
+		},
+		addToBasketFn: func(_ context.Context, payload map[string]any, _ woltgateway.AuthContext) (map[string]any, error) {
+			captured = payload
+			return map[string]any{"id": "basket-1"}, nil
+		},
+	}
+	tc := newToolCtx(Deps{
+		Wolt:     wolt,
+		Profiles: &stubProfiles{profile: domain.Profile{Name: "default", WToken: "token"}},
+		Location: &stubLocation{},
+		Config:   &stubConfig{},
+	})
+
+	_, _, err := tc.handleCartAdd(context.Background(), nil, CartAddInput{
+		LocationInput: LocationInput{Lat: 41.7, Lon: 44.8},
+		Venue:         "test-venue",
+		ItemID:        itemID,
+	})
+	if err != nil {
+		t.Fatalf("handleCartAdd: %v", err)
+	}
+	if captured["currency"] != "GEL" {
+		t.Fatalf("currency = %v, want GEL", captured["currency"])
+	}
+}
+
+func TestHandleVenueItemReturnsCurrentImageAndAvailability(t *testing.T) {
+	const venueID = "5f9a1b2c3d4e5f6071829304"
+	const itemID = "627cb2c7e2a6f0a1b2c3d4e5"
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Chicken thigh",
+					"price":               1645,
+					"images":              []any{map[string]any{"url": "https://example.test/chicken.jpg", "blurhash": "abc"}},
+					"purchasable_balance": 8,
+				},
+			}}, nil
+		},
+	}
+	tc := newToolCtx(Deps{Wolt: wolt, Profiles: &stubProfiles{}, Location: &stubLocation{}, Config: &stubConfig{}})
+
+	_, out, err := tc.handleVenueItem(context.Background(), nil, VenueItemInput{
+		Venue:  "test-venue",
+		ItemID: itemID,
+	})
+	if err != nil {
+		t.Fatalf("handleVenueItem: %v", err)
+	}
+	if out.Item["image_url"] != "https://example.test/chicken.jpg" {
+		t.Fatalf("image_url = %v", out.Item["image_url"])
+	}
+	if out.Item["is_available"] != true {
+		t.Fatalf("is_available = %v, want true", out.Item["is_available"])
+	}
+}
+
 // ---------------- helpers ----------------
 
 func connectInMemory(t *testing.T, deps Deps) (*mcp.Server, *mcp.ClientSession) {
@@ -395,6 +520,7 @@ type stubWolt struct {
 	userMeFn           func(context.Context, woltgateway.AuthContext) (map[string]any, error)
 	restaurantFn       func(context.Context, string) (*domain.Restaurant, error)
 	assortmentSearchFn func(context.Context, string, string, string, woltgateway.AuthContext) (map[string]any, error)
+	assortmentItemsFn  func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error)
 	venueStaticFn      func(context.Context, string) (map[string]any, error)
 	venueDynamicFn     func(context.Context, string, woltgateway.VenuePageDynamicOptions) (map[string]any, error)
 	addToBasketFn      func(context.Context, map[string]any, woltgateway.AuthContext) (map[string]any, error)
@@ -444,8 +570,11 @@ func (s *stubWolt) AssortmentByVenueSlug(context.Context, string) (map[string]an
 func (s *stubWolt) AssortmentCategoryByVenueSlug(context.Context, string, string, string, woltgateway.AuthContext) (map[string]any, error) {
 	return map[string]any{}, nil
 }
-func (s *stubWolt) AssortmentItemsByVenueSlug(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
-	return map[string]any{}, nil
+func (s *stubWolt) AssortmentItemsByVenueSlug(ctx context.Context, slug string, itemIDs []string, auth woltgateway.AuthContext) (map[string]any, error) {
+	if s.assortmentItemsFn != nil {
+		return s.assortmentItemsFn(ctx, slug, itemIDs, auth)
+	}
+	return availableStubItems(itemIDs), nil
 }
 func (s *stubWolt) AssortmentItemsSearchByVenueSlug(ctx context.Context, slug string, query string, language string, auth woltgateway.AuthContext) (map[string]any, error) {
 	if s.assortmentSearchFn != nil {
@@ -530,6 +659,18 @@ func (s *stubWolt) CheckoutPreview(ctx context.Context, payload map[string]any, 
 }
 func (s *stubWolt) RefreshAccessToken(context.Context, string, woltgateway.AuthContext) (woltgateway.TokenRefreshResult, error) {
 	return woltgateway.TokenRefreshResult{}, nil
+}
+
+func availableStubItems(itemIDs []string) map[string]any {
+	items := make([]any, 0, len(itemIDs))
+	for _, itemID := range itemIDs {
+		items = append(items, map[string]any{
+			"id":                  itemID,
+			"name":                itemID,
+			"purchasable_balance": 10,
+		})
+	}
+	return map[string]any{"items": items}
 }
 
 type stubProfiles struct {

--- a/internal/mcpserver/server_test.go
+++ b/internal/mcpserver/server_test.go
@@ -365,7 +365,10 @@ func TestHandleCartAddBlocksUnavailableItemEvenWithOverrides(t *testing.T) {
 		venueStaticFn: func(context.Context, string) (map[string]any, error) {
 			return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
 		},
-		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+		assortmentItemsFn: func(_ context.Context, _ string, _ []string, auth woltgateway.AuthContext) (map[string]any, error) {
+			if auth.HasCredentials() {
+				return nil, errors.New("authenticated public catalog read rejected")
+			}
 			return map[string]any{"items": []any{
 				map[string]any{
 					"id":                  itemID,

--- a/internal/mcpserver/tools_cart.go
+++ b/internal/mcpserver/tools_cart.go
@@ -172,7 +172,7 @@ func (tc *ToolCtx) handleCartAdd(ctx context.Context, _ *mcp.CallToolRequest, in
 		)
 	}
 	currentAssortment, err := invokeWithRefresh(ctx, tc, &auth, func(a woltgateway.AuthContext) (map[string]any, error) {
-		return tc.wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, []string{in.ItemID}, a)
+		return requestAssortmentItems(ctx, tc, venueSlug, []string{in.ItemID}, a)
 	})
 	if err != nil {
 		return nil, CartAddOutput{}, toolErr(fmt.Errorf("current item availability lookup failed: %w", err))

--- a/internal/mcpserver/tools_cart.go
+++ b/internal/mcpserver/tools_cart.go
@@ -9,6 +9,8 @@ import (
 
 	"github.com/mekedron/wolt-cli/internal/domain"
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
 )
 
 func registerCartTools(srv *mcp.Server, tc *ToolCtx) {
@@ -35,7 +37,7 @@ func registerCartTools(srv *mcp.Server, tc *ToolCtx) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wolt_cart_add",
 		Title:       "Add an item to a basket",
-		Description: "Add an item to a venue's basket. Merges with existing basket items (does not replace them). If price is omitted, looks the item up via the menu and uses its current price.",
+		Description: "Add an item after revalidating its current availability. Merges with existing basket items (does not replace them) and resolves current price and venue currency.",
 		Annotations: mutateAdd,
 	}, tc.handleCartAdd)
 
@@ -162,33 +164,61 @@ func (tc *ToolCtx) handleCartAdd(ctx context.Context, _ *mcp.CallToolRequest, in
 			in.Venue,
 		)
 	}
+	venueSlug := strings.TrimSpace(ref.Slug)
+	if venueSlug == "" {
+		return nil, CartAddOutput{}, toolErrf(
+			"current item availability could not be verified for venue %s; pass a venue slug or Wolt venue/item URL",
+			ref.ID,
+		)
+	}
+	currentAssortment, err := invokeWithRefresh(ctx, tc, &auth, func(a woltgateway.AuthContext) (map[string]any, error) {
+		return tc.wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, []string{in.ItemID}, a)
+	})
+	if err != nil {
+		return nil, CartAddOutput{}, toolErr(fmt.Errorf("current item availability lookup failed: %w", err))
+	}
+	issues := catalogitem.ValidateItemIDs(currentAssortment, []string{in.ItemID})
+	if len(issues) > 0 {
+		return nil, CartAddOutput{}, toolErrf(
+			"item was NOT added because current availability validation failed: %s",
+			catalogitem.FormatValidationIssues(issues),
+		)
+	}
+	currentItem := catalogitem.Find(currentAssortment, in.ItemID)
 
-	// Resolve price/name from the item page if not provided.
+	// Availability is always checked above, even when callers provide all
+	// display metadata explicitly. Resolve missing values from the fresh
+	// assortment item first and use the item page only as a fallback.
 	price := in.Price
-	currency := strings.TrimSpace(in.Currency)
+	currency := payloadutil.NormalizeCurrency(in.Currency)
 	name := strings.TrimSpace(in.Name)
-	if price <= 0 || currency == "" || name == "" {
-		itemPayload, itemErr := tc.wolt.VenueItemPage(ctx, ref.ID, in.ItemID)
-		if itemErr != nil {
-			return nil, CartAddOutput{}, toolErr(fmt.Errorf("item lookup failed (pass price/currency/name explicitly to skip): %w", itemErr))
-		}
+	itemPayload := map[string]any{}
+	if price <= 0 {
+		price = asInt(currentItem["price"])
 		if price <= 0 {
-			price = asInt(asMap(itemPayload["price"])["amount"])
+			price = asInt(asMap(currentItem["price"])["amount"])
 		}
-		if currency == "" {
-			currency = asString(asMap(itemPayload["price"])["currency"])
-		}
-		if name == "" {
-			name = asString(coalesceAny(itemPayload["name"], itemPayload["title"]))
+	}
+	if name == "" {
+		name = asString(coalesceAny(currentItem["name"], currentItem["title"]))
+	}
+	if price <= 0 || currency == "" || name == "" {
+		if fetched, itemErr := tc.wolt.VenueItemPage(ctx, ref.ID, in.ItemID); itemErr == nil {
+			itemPayload = fetched
+			if price <= 0 {
+				price = asInt(asMap(itemPayload["price"])["amount"])
+			}
+			if currency == "" {
+				currency = payloadutil.NormalizeCurrency(asString(asMap(itemPayload["price"])["currency"]))
+			}
+			if name == "" {
+				name = asString(coalesceAny(itemPayload["name"], itemPayload["title"]))
+			}
 		}
 	}
 	if price <= 0 {
 		return nil, CartAddOutput{}, toolErrf("could not determine item price; pass `price` in minor units")
 	}
-	if currency == "" {
-		currency = "EUR"
-	}
-
 	loc, _, err := tc.resolveLocation(ctx, in.LocationInput)
 	if err != nil {
 		return nil, CartAddOutput{}, toolErr(err)
@@ -208,10 +238,22 @@ func (tc *ToolCtx) handleCartAdd(ctx context.Context, _ *mcp.CallToolRequest, in
 	// Fetch existing basket to preserve other lines (Wolt's AddToBasket replaces
 	// the items array wholesale).
 	mergedItems := []any{newLine}
-	if existingPage, e := tc.wolt.BasketsPage(ctx, loc, auth); e == nil {
-		if basket := selectBasketForVenue(existingPage, ref.ID); basket != nil {
-			mergedItems = mergeBasketItems(basket, in.ItemID, count, newLine)
+	var existingBasket map[string]any
+	if existingPage, e := invokeWithRefresh(ctx, tc, &auth, func(a woltgateway.AuthContext) (map[string]any, error) {
+		return tc.wolt.BasketsPage(ctx, loc, a)
+	}); e == nil {
+		existingBasket = selectBasketForVenue(existingPage, ref.ID)
+		if existingBasket != nil {
+			mergedItems = mergeBasketItems(existingBasket, in.ItemID, count, newLine)
 		}
+	}
+	if currency == "" {
+		currency = resolveVenueCurrency(ctx, tc, ref, existingBasket, currentAssortment, itemPayload)
+	}
+	if currency == "" {
+		return nil, CartAddOutput{}, toolErrf(
+			"item was NOT added because the venue currency could not be verified",
+		)
 	}
 
 	addPayload := map[string]any{
@@ -275,9 +317,11 @@ func (tc *ToolCtx) handleCartRemove(ctx context.Context, _ *mcp.CallToolRequest,
 	if basket == nil {
 		return nil, CartRemoveOutput{}, toolErrf("no basket found for venue %s", ref.ID)
 	}
-	currency := strings.TrimSpace(asString(coalesceAny(basket["currency"], asMap(basket["total_price"])["currency"])))
+	currency := resolveVenueCurrency(ctx, tc, ref, basket)
 	if currency == "" {
-		currency = "EUR"
+		return nil, CartRemoveOutput{}, toolErrf(
+			"item quantity was not changed because the venue currency could not be verified",
+		)
 	}
 
 	removed := 0

--- a/internal/mcpserver/tools_checkout.go
+++ b/internal/mcpserver/tools_checkout.go
@@ -79,7 +79,7 @@ func (tc *ToolCtx) handleCheckoutPreview(ctx context.Context, _ *mcp.CallToolReq
 	basketVenue["slug"] = venueSlug
 	basketItemIDs := catalogitem.BasketItemIDs(basket)
 	currentItems, err := invokeWithRefresh(ctx, tc, &auth, func(a woltgateway.AuthContext) (map[string]any, error) {
-		return tc.wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, basketItemIDs, a)
+		return requestAssortmentItems(ctx, tc, venueSlug, basketItemIDs, a)
 	})
 	if err != nil {
 		return nil, CheckoutPreviewOutput{}, toolErr(fmt.Errorf("current basket availability lookup failed: %w", err))

--- a/internal/mcpserver/tools_checkout.go
+++ b/internal/mcpserver/tools_checkout.go
@@ -2,11 +2,13 @@ package mcpserver
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/checkoutpayload"
 )
 
@@ -25,7 +27,7 @@ type CheckoutPreviewInput struct {
 	LocationInput
 	Venue        string `json:"venue"                    jsonschema:"venue slug, id, or url"`
 	DeliveryMode string `json:"delivery_mode,omitempty"  jsonschema:"standard | priority | schedule"`
-	Tip          int    `json:"tip,omitempty"            jsonschema:"tip in minor units (e.g. 200 = EUR 2.00)"`
+	Tip          int    `json:"tip,omitempty"            jsonschema:"tip in minor units (e.g. 200 = 2.00 in the venue currency)"`
 	PromoCode    string `json:"promo_code,omitempty"     jsonschema:"promo code to apply"`
 }
 
@@ -62,6 +64,32 @@ func (tc *ToolCtx) handleCheckoutPreview(ctx context.Context, _ *mcp.CallToolReq
 	basket := selectBasketForVenue(basketsPage, ref.ID)
 	if basket == nil {
 		return nil, CheckoutPreviewOutput{}, toolErrf("no basket found for venue %s; add items first via wolt_cart_add", ref.ID)
+	}
+	venueSlug := strings.TrimSpace(ref.Slug)
+	if venueSlug == "" {
+		return nil, CheckoutPreviewOutput{}, toolErrf(
+			"checkout preview blocked because the venue slug could not be resolved for current item validation",
+		)
+	}
+	basketVenue := asMap(basket["venue"])
+	if basketVenue == nil {
+		basketVenue = map[string]any{}
+		basket["venue"] = basketVenue
+	}
+	basketVenue["slug"] = venueSlug
+	basketItemIDs := catalogitem.BasketItemIDs(basket)
+	currentItems, err := invokeWithRefresh(ctx, tc, &auth, func(a woltgateway.AuthContext) (map[string]any, error) {
+		return tc.wolt.AssortmentItemsByVenueSlug(ctx, venueSlug, basketItemIDs, a)
+	})
+	if err != nil {
+		return nil, CheckoutPreviewOutput{}, toolErr(fmt.Errorf("current basket availability lookup failed: %w", err))
+	}
+	issues := catalogitem.ValidateItemIDs(currentItems, basketItemIDs)
+	if len(issues) > 0 {
+		return nil, CheckoutPreviewOutput{}, toolErrf(
+			"checkout preview blocked because the basket contains unavailable items: %s",
+			catalogitem.FormatValidationIssues(issues),
+		)
 	}
 
 	deliveryMode := strings.TrimSpace(in.DeliveryMode)

--- a/internal/mcpserver/tools_checkout_test.go
+++ b/internal/mcpserver/tools_checkout_test.go
@@ -2,6 +2,7 @@ package mcpserver
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/mekedron/wolt-cli/internal/domain"
@@ -19,6 +20,9 @@ func TestHandleCheckoutPreviewSendsPurchasePlan(t *testing.T) {
 	var captured map[string]any
 	checkoutCalled := false
 	wolt := &stubWolt{
+		restaurantFn: func(context.Context, string) (*domain.Restaurant, error) {
+			return &domain.Restaurant{ID: venueID, Slug: "test-venue"}, nil
+		},
 		basketsPageFn: func(context.Context, domain.Location, woltgateway.AuthContext) (map[string]any, error) {
 			return map[string]any{
 				"baskets": []any{
@@ -78,6 +82,60 @@ func TestHandleCheckoutPreviewSendsPurchasePlan(t *testing.T) {
 		if _, exists := captured[banned]; exists {
 			t.Errorf("upstream payload must not contain top-level %q (old rejected MCP shape)", banned)
 		}
+	}
+}
+
+func TestHandleCheckoutPreviewBlocksUnavailableBasketItem(t *testing.T) {
+	const venueID = "5f9a1b2c3d4e5f6071829304"
+	const itemID = "627cb2c7e2a6f0a1b2c3d4e5"
+
+	checkoutCalled := false
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
+		},
+		basketsPageFn: func(context.Context, domain.Location, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"baskets": []any{
+				map[string]any{
+					"venue": map[string]any{"id": venueID, "slug": "test-venue"},
+					"total": "GEL5.00",
+					"items": []any{map[string]any{
+						"id": itemID, "name": "Unavailable chicken", "count": 1, "price": 500,
+					}},
+				},
+			}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Unavailable chicken",
+					"disabled_info":       map[string]any{"disable_text": "Sold out"},
+					"purchasable_balance": 0,
+				},
+			}}, nil
+		},
+		checkoutPreviewFn: func(context.Context, map[string]any, woltgateway.AuthContext) (map[string]any, error) {
+			checkoutCalled = true
+			return map[string]any{}, nil
+		},
+	}
+	tc := newToolCtx(Deps{
+		Wolt:     wolt,
+		Profiles: &stubProfiles{profile: domain.Profile{Name: "default", WToken: "token"}},
+		Location: &stubLocation{},
+		Config:   &stubConfig{},
+	})
+
+	_, _, err := tc.handleCheckoutPreview(context.Background(), nil, CheckoutPreviewInput{
+		LocationInput: LocationInput{Lat: 41.7, Lon: 44.8},
+		Venue:         "test-venue",
+	})
+	if err == nil || !strings.Contains(err.Error(), "Sold out") {
+		t.Fatalf("expected Sold out validation error, got %v", err)
+	}
+	if checkoutCalled {
+		t.Fatal("CheckoutPreview must not be called when a basket item is unavailable")
 	}
 }
 

--- a/internal/mcpserver/tools_venue.go
+++ b/internal/mcpserver/tools_venue.go
@@ -198,8 +198,9 @@ func (tc *ToolCtx) handleVenueItem(ctx context.Context, _ *mcp.CallToolRequest, 
 	payload, pageErr := tc.wolt.VenueItemPage(ctx, ref.ID, in.ItemID)
 	var currentItem map[string]any
 	if strings.TrimSpace(ref.Slug) != "" {
-		currentPayload, currentErr := tc.wolt.AssortmentItemsByVenueSlug(
+		currentPayload, currentErr := requestAssortmentItems(
 			ctx,
+			tc,
 			ref.Slug,
 			[]string{in.ItemID},
 			tc.optionalAuth(ctx),

--- a/internal/mcpserver/tools_venue.go
+++ b/internal/mcpserver/tools_venue.go
@@ -8,6 +8,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/mekedron/wolt-cli/internal/domain"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/observability"
 )
 
@@ -24,7 +25,7 @@ func registerVenueTools(srv *mcp.Server, tc *ToolCtx) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wolt_venue_menu",
 		Title:       "Venue menu",
-		Description: "Browse a venue's menu. Returns normalized items with prices, discounts, sold-out flags. Supports query/category filters and pagination.",
+		Description: "Browse a venue's menu. Returns normalized items with prices, image URLs, discounts, and current availability. Supports query/category filters and pagination.",
 		Annotations: readOnly,
 	}, tc.handleVenueMenu)
 
@@ -38,7 +39,7 @@ func registerVenueTools(srv *mcp.Server, tc *ToolCtx) {
 	mcp.AddTool(srv, &mcp.Tool{
 		Name:        "wolt_venue_item",
 		Title:       "Item detail",
-		Description: "Fetch one item's full payload (name, price, options, sold-out, description). Useful before adding to a cart so you know the item id, price, and currency.",
+		Description: "Fetch one item's current payload (name, price, image URLs, options, availability, description). Useful before adding to a cart.",
 		Annotations: readOnly,
 	}, tc.handleVenueItem)
 
@@ -194,9 +195,26 @@ func (tc *ToolCtx) handleVenueItem(ctx context.Context, _ *mcp.CallToolRequest, 
 	if strings.TrimSpace(in.ItemID) == "" {
 		return nil, VenueItemOutput{}, toolErrf("item_id is required")
 	}
-	payload, err := tc.wolt.VenueItemPage(ctx, ref.ID, in.ItemID)
-	if err != nil {
-		return nil, VenueItemOutput{}, toolErr(err)
+	payload, pageErr := tc.wolt.VenueItemPage(ctx, ref.ID, in.ItemID)
+	var currentItem map[string]any
+	if strings.TrimSpace(ref.Slug) != "" {
+		currentPayload, currentErr := tc.wolt.AssortmentItemsByVenueSlug(
+			ctx,
+			ref.Slug,
+			[]string{in.ItemID},
+			tc.optionalAuth(ctx),
+		)
+		if currentErr == nil {
+			currentItem = catalogitem.Find(currentPayload, in.ItemID)
+		}
+	}
+	if currentItem != nil {
+		payload = catalogitem.MergeCurrentItem(payload, currentItem)
+	} else if pageErr != nil {
+		return nil, VenueItemOutput{}, toolErr(pageErr)
+	}
+	if currency := resolveVenueCurrency(ctx, tc, ref, nil, payload); currency != "" {
+		payload["currency"] = currency
 	}
 	data, _ := observability.BuildItemDetail(in.ItemID, ref.ID, payload, false)
 	return nil, VenueItemOutput{

--- a/internal/service/catalogitem/catalogitem.go
+++ b/internal/service/catalogitem/catalogitem.go
@@ -1,0 +1,270 @@
+package catalogitem
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
+)
+
+// Availability describes whether Wolt currently allows an item to be
+// purchased. Current Wolt assortment payloads use disabled_info as the
+// authoritative switch; purchasable_balance is an additional inventory guard.
+type Availability struct {
+	IsAvailable        bool
+	Reason             string
+	PurchasableBalance any
+}
+
+// ValidationIssue identifies a basket item that cannot safely be purchased.
+type ValidationIssue struct {
+	ItemID string
+	Name   string
+	Reason string
+}
+
+// ResolveAvailability interprets the current consumer-assortment item schema.
+// A nil disabled_info means enabled. A present object means disabled even when
+// it carries no human-readable reason, matching Wolt's web client.
+func ResolveAvailability(item map[string]any) Availability {
+	result := Availability{
+		IsAvailable:        true,
+		PurchasableBalance: item["purchasable_balance"],
+	}
+
+	if disabledInfo := payloadutil.Map(item["disabled_info"]); disabledInfo != nil {
+		result.IsAvailable = false
+		result.Reason = strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(
+			disabledInfo["disable_text"],
+			disabledInfo["disabled_reason"],
+			disabledInfo["disable_reason"],
+		)))
+		if result.Reason == "" {
+			result.Reason = "item is disabled by Wolt"
+		}
+		return result
+	}
+
+	if balance, ok := number(item["purchasable_balance"]); ok && balance <= 0 {
+		result.IsAvailable = false
+		result.Reason = "purchasable balance is zero"
+	}
+	return result
+}
+
+// Find locates one item in an assortment or item-selection payload.
+func Find(payload map[string]any, itemID string) map[string]any {
+	target := strings.TrimSpace(itemID)
+	if target == "" || payload == nil {
+		return nil
+	}
+
+	var found map[string]any
+	var walk func(any)
+	walk = func(value any) {
+		if found != nil {
+			return
+		}
+		switch typed := value.(type) {
+		case map[string]any:
+			id := strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(
+				typed["item_id"],
+				typed["id"],
+			)))
+			name := strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(
+				typed["name"],
+				typed["title"],
+			)))
+			if id == target && name != "" {
+				found = typed
+				return
+			}
+			for _, nested := range typed {
+				walk(nested)
+			}
+		case []any:
+			for _, nested := range typed {
+				walk(nested)
+			}
+		}
+	}
+	walk(payload)
+	return found
+}
+
+// BasketItemIDs returns unique non-empty item ids while preserving line order.
+func BasketItemIDs(basket map[string]any) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, raw := range payloadutil.Slice(basket["items"]) {
+		line := payloadutil.Map(raw)
+		itemID := strings.TrimSpace(payloadutil.String(line["id"]))
+		if itemID == "" {
+			continue
+		}
+		if _, exists := seen[itemID]; exists {
+			continue
+		}
+		seen[itemID] = struct{}{}
+		out = append(out, itemID)
+	}
+	return out
+}
+
+// ValidateItemIDs checks a fresh assortment/items response. Missing ids fail
+// closed because continuing would repeat the stale-cart behaviour this check
+// is meant to prevent.
+func ValidateItemIDs(payload map[string]any, itemIDs []string) []ValidationIssue {
+	issues := []ValidationIssue{}
+	for _, itemID := range itemIDs {
+		item := Find(payload, itemID)
+		if item == nil {
+			issues = append(issues, ValidationIssue{
+				ItemID: itemID,
+				Name:   itemID,
+				Reason: "item is missing from the current assortment",
+			})
+			continue
+		}
+		availability := ResolveAvailability(item)
+		if availability.IsAvailable {
+			continue
+		}
+		name := strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(item["name"], item["title"])))
+		if name == "" {
+			name = itemID
+		}
+		issues = append(issues, ValidationIssue{
+			ItemID: itemID,
+			Name:   name,
+			Reason: availability.Reason,
+		})
+	}
+	return issues
+}
+
+// FormatValidationIssues produces a concise mutation/checkout error.
+func FormatValidationIssues(issues []ValidationIssue) string {
+	parts := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		label := strings.TrimSpace(issue.Name)
+		if label == "" {
+			label = strings.TrimSpace(issue.ItemID)
+		}
+		if reason := strings.TrimSpace(issue.Reason); reason != "" {
+			label += ": " + reason
+		}
+		parts = append(parts, label)
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ImageURLs returns all non-empty product image URLs in upstream order.
+func ImageURLs(item map[string]any) []string {
+	images := imageObjects(item["images"])
+	urls := make([]string, 0, len(images))
+	seen := map[string]struct{}{}
+	for _, image := range images {
+		url := strings.TrimSpace(payloadutil.String(image["url"]))
+		if url == "" {
+			continue
+		}
+		if _, exists := seen[url]; exists {
+			continue
+		}
+		seen[url] = struct{}{}
+		urls = append(urls, url)
+	}
+	return urls
+}
+
+// ImageBlurhash returns the first non-empty image blurhash.
+func ImageBlurhash(item map[string]any) string {
+	for _, image := range imageObjects(item["images"]) {
+		if blurhash := strings.TrimSpace(payloadutil.String(image["blurhash"])); blurhash != "" {
+			return blurhash
+		}
+	}
+	return ""
+}
+
+// MergeCurrentItem overlays a fresh assortment item onto an item-page payload.
+// Item-page payloads still carry useful option groups, while the exact
+// assortment response is authoritative for price, images and availability.
+func MergeCurrentItem(base map[string]any, current map[string]any) map[string]any {
+	merged := map[string]any{}
+	for key, value := range base {
+		merged[key] = value
+	}
+	for key, value := range current {
+		merged[key] = value
+	}
+	return merged
+}
+
+func imageObjects(value any) []map[string]any {
+	if single := payloadutil.Map(value); single != nil {
+		return []map[string]any{single}
+	}
+	out := []map[string]any{}
+	for _, raw := range payloadutil.Slice(value) {
+		if image := payloadutil.Map(raw); image != nil {
+			out = append(out, image)
+		}
+	}
+	return out
+}
+
+func number(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int8:
+		return float64(typed), true
+	case int16:
+		return float64(typed), true
+	case int32:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case uint:
+		return float64(typed), true
+	case uint8:
+		return float64(typed), true
+	case uint16:
+		return float64(typed), true
+	case uint32:
+		return float64(typed), true
+	case uint64:
+		return float64(typed), true
+	case float32:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case json.Number:
+		parsed, err := typed.Float64()
+		return parsed, err == nil
+	case string:
+		parsed, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		return parsed, err == nil
+	default:
+		return 0, false
+	}
+}
+
+// UnavailableMessage creates a stable human-readable mutation error.
+func UnavailableMessage(itemID string, item map[string]any, availability Availability) string {
+	name := strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(item["name"], item["title"])))
+	if name == "" {
+		name = strings.TrimSpace(itemID)
+	}
+	if name == "" {
+		name = "item"
+	}
+	if availability.Reason == "" {
+		return fmt.Sprintf("%s is unavailable", name)
+	}
+	return fmt.Sprintf("%s is unavailable: %s", name, availability.Reason)
+}

--- a/internal/service/catalogitem/catalogitem_test.go
+++ b/internal/service/catalogitem/catalogitem_test.go
@@ -1,0 +1,114 @@
+package catalogitem
+
+import "testing"
+
+func TestResolveAvailability(t *testing.T) {
+	tests := []struct {
+		name       string
+		item       map[string]any
+		available  bool
+		wantReason string
+	}{
+		{
+			name:      "nil disabled info and unknown balance is available",
+			item:      map[string]any{"disabled_info": nil, "purchasable_balance": nil},
+			available: true,
+		},
+		{
+			name: "disabled info is authoritative",
+			item: map[string]any{
+				"disabled_info":       map[string]any{"disable_text": "Sold out"},
+				"purchasable_balance": 12,
+			},
+			available:  false,
+			wantReason: "Sold out",
+		},
+		{
+			name: "zero balance blocks purchase",
+			item: map[string]any{
+				"disabled_info":       nil,
+				"purchasable_balance": 0,
+			},
+			available:  false,
+			wantReason: "purchasable balance is zero",
+		},
+		{
+			name: "positive balance is available",
+			item: map[string]any{
+				"disabled_info":       nil,
+				"purchasable_balance": 3,
+			},
+			available: true,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			got := ResolveAvailability(test.item)
+			if got.IsAvailable != test.available {
+				t.Fatalf("IsAvailable = %v, want %v", got.IsAvailable, test.available)
+			}
+			if got.Reason != test.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, test.wantReason)
+			}
+		})
+	}
+}
+
+func TestFindAndImages(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":   "item-1",
+				"name": "Chicken",
+				"images": []any{
+					map[string]any{"url": "https://example.test/one.jpg", "blurhash": "hash"},
+					map[string]any{"url": "https://example.test/two.jpg"},
+				},
+			},
+		},
+	}
+
+	item := Find(payload, "item-1")
+	if item == nil {
+		t.Fatal("Find returned nil")
+	}
+	urls := ImageURLs(item)
+	if len(urls) != 2 || urls[0] != "https://example.test/one.jpg" || urls[1] != "https://example.test/two.jpg" {
+		t.Fatalf("ImageURLs = %#v", urls)
+	}
+	if got := ImageBlurhash(item); got != "hash" {
+		t.Fatalf("ImageBlurhash = %q, want hash", got)
+	}
+}
+
+func TestValidateItemIDsFailsClosed(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":                  "available",
+				"name":                "Available",
+				"disabled_info":       nil,
+				"purchasable_balance": nil,
+			},
+			map[string]any{
+				"id":                  "sold-out",
+				"name":                "Sold out item",
+				"disabled_info":       map[string]any{"disable_text": "Sold out"},
+				"purchasable_balance": 0,
+			},
+		},
+	}
+
+	issues := ValidateItemIDs(payload, []string{"available", "sold-out", "missing"})
+	if len(issues) != 2 {
+		t.Fatalf("issues = %#v, want two", issues)
+	}
+	if issues[0].ItemID != "sold-out" || issues[0].Reason != "Sold out" {
+		t.Fatalf("unexpected sold-out issue: %#v", issues[0])
+	}
+	if issues[1].ItemID != "missing" {
+		t.Fatalf("unexpected missing issue: %#v", issues[1])
+	}
+}

--- a/internal/service/checkoutpayload/checkoutpayload.go
+++ b/internal/service/checkoutpayload/checkoutpayload.go
@@ -36,23 +36,35 @@ func Build(
 
 	venue := payloadutil.Map(basket["venue"])
 	venueID := strings.TrimSpace(payloadutil.String(venue["id"]))
-	currency := resolveCheckoutCurrency(basket)
-	country := strings.TrimSpace(payloadutil.String(venue["country"]))
 	warnings := []string{}
 	itemDetails := map[string]map[string]any{}
 	categoryIDsByItemID := map[string]string{}
 	assortmentPayload := map[string]any{}
+	staticPayload := map[string]any{}
 
 	venueSlug := resolveBasketVenueSlug(venue)
+	if venueSlug != "" && venuePageStatic != nil {
+		if payload, err := venuePageStatic(ctx, venueSlug); err == nil {
+			staticPayload = payload
+			mergeCheckoutCategoryIndexes(categoryIDsByItemID, buildCheckoutCategoryIDIndex(payload))
+		}
+	}
+	currency := resolveCheckoutCurrency(basket, staticPayload)
+	if currency == "" {
+		return nil, warnings, fmt.Errorf("unable to resolve venue currency for checkout preview")
+	}
+	country := strings.TrimSpace(payloadutil.String(venue["country"]))
+	if country == "" {
+		staticVenue := payloadutil.Map(staticPayload["venue"])
+		country = strings.TrimSpace(payloadutil.String(staticVenue["country"]))
+	}
+
 	if venueSlug != "" && wolt != nil {
 		if payload, err := wolt.AssortmentByVenueSlug(ctx, venueSlug); err == nil {
 			assortmentPayload = payload
 			mergeCheckoutCategoryIndexes(categoryIDsByItemID, buildCheckoutCategoryIDIndex(payload))
 		} else {
 			warnings = append(warnings, fmt.Sprintf("unable to load venue assortment payload for category mapping (slug=%s)", venueSlug))
-		}
-		if payload, err := venuePageStatic(ctx, venueSlug); err == nil {
-			mergeCheckoutCategoryIndexes(categoryIDsByItemID, buildCheckoutCategoryIDIndex(payload))
 		}
 	}
 
@@ -149,24 +161,14 @@ func Build(
 	}, warnings, nil
 }
 
-// resolveCheckoutCurrency picks the basket currency, preferring the value Wolt
-// states explicitly (basket.currency / basket.total_price.currency) over a guess
-// from the formatted total. InferCurrency only recognises a few symbols (EUR,
-// USD, PLN), so inferring alone sends EUR for markets like SEK/DKK/NOK whose
-// total is absent, structured, or uses an unrecognised symbol — which can make
-// Wolt reject or mis-price the preview. Inference and the EUR default remain as
-// last resorts so behaviour is unchanged when no explicit currency is present.
-func resolveCheckoutCurrency(basket map[string]any) string {
-	if c := strings.TrimSpace(payloadutil.String(payloadutil.CoalesceAny(
-		basket["currency"],
-		payloadutil.Map(basket["total_price"])["currency"],
-	))); c != "" {
-		return c
+// resolveCheckoutCurrency never guesses a market-wide default. Sending EUR for
+// a GEL/SEK/DKK basket can mis-price or invalidate the request, so checkout
+// fails closed when neither the basket nor venue payload states a currency.
+func resolveCheckoutCurrency(basket map[string]any, venuePayload map[string]any) string {
+	if currency := payloadutil.CurrencyFromBasket(basket); currency != "" {
+		return currency
 	}
-	if c := payloadutil.InferCurrency(payloadutil.String(basket["total"])); c != "" {
-		return c
-	}
-	return "EUR"
+	return payloadutil.CurrencyFromVenuePayload(venuePayload)
 }
 
 func resolveCheckoutCategoryID(item map[string]any, detail map[string]any, itemID string, fallback map[string]string) string {

--- a/internal/service/checkoutpayload/checkoutpayload_test.go
+++ b/internal/service/checkoutpayload/checkoutpayload_test.go
@@ -205,15 +205,17 @@ func TestBuildRejectsMissingBasePrice(t *testing.T) {
 	}
 }
 
-func TestBuildCurrencyInferenceAndDefault(t *testing.T) {
+func TestBuildCurrencyInferenceFailsClosedWithoutCurrency(t *testing.T) {
 	cases := []struct {
-		total string
-		want  string
+		total   string
+		want    string
+		wantErr bool
 	}{
-		{"$9.99", "USD"},
-		{"€4.00", "EUR"},
-		{"", "EUR"},      // no symbol -> default EUR
-		{"12.00", "EUR"}, // unrecognised -> default EUR
+		{"$9.99", "USD", false},
+		{"€4.00", "EUR", false},
+		{"GEL0.00", "GEL", false},
+		{"", "", true},
+		{"12.00", "", true},
 	}
 	for _, c := range cases {
 		basket := basketWithItem(c.total, map[string]any{
@@ -221,6 +223,12 @@ func TestBuildCurrencyInferenceAndDefault(t *testing.T) {
 		})
 		payload, _, err := Build(context.Background(), nil, nil, basket,
 			domain.Location{}, "standard", 0, "")
+		if c.wantErr {
+			if err == nil || !strings.Contains(err.Error(), "currency") {
+				t.Fatalf("total %q: expected currency error, got %v", c.total, err)
+			}
+			continue
+		}
 		if err != nil {
 			t.Fatalf("total %q: %v", c.total, err)
 		}
@@ -228,6 +236,32 @@ func TestBuildCurrencyInferenceAndDefault(t *testing.T) {
 		if venue["currency"] != c.want {
 			t.Errorf("total %q: currency = %v, want %v", c.total, venue["currency"], c.want)
 		}
+	}
+}
+
+func TestBuildUsesVenueCurrencyWhenBasketOmitsIt(t *testing.T) {
+	basket := basketWithItem("", map[string]any{
+		"id": "627cb2c7e2a6f0a1b2c3d4e5", "count": 1, "price": 500, "category_id": "cat",
+	})
+	basket["venue"].(map[string]any)["slug"] = "biubiu-moscow-ave"
+	payload, _, err := Build(
+		context.Background(),
+		nil,
+		func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"venue": map[string]any{"currency": "GEL"}}, nil
+		},
+		basket,
+		domain.Location{},
+		"standard",
+		0,
+		"",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	venue := purchasePlan(t, payload)["venue"].(map[string]any)
+	if venue["currency"] != "GEL" {
+		t.Fatalf("currency = %v, want GEL", venue["currency"])
 	}
 }
 

--- a/internal/service/observability/items.go
+++ b/internal/service/observability/items.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 )
 
 func walkObjects(node any) []map[string]any {
@@ -401,7 +403,15 @@ func ExtractMenuItems(payload map[string]any, venueID string, venueSlug string) 
 			continue
 		}
 
-		signalKeys := []string{"option_group_ids", "option_groups", "base_price", "price", "is_sold_out", "sold_out", "item_id"}
+		signalKeys := []string{
+			"option_group_ids",
+			"option_groups",
+			"base_price",
+			"price",
+			"disabled_info",
+			"purchasable_balance",
+			"item_id",
+		}
 		if hasAnyKeys(obj, "options") {
 			signalKeys = append(signalKeys, "options")
 		}
@@ -431,7 +441,12 @@ func ExtractMenuItems(payload map[string]any, venueID string, venueSlug string) 
 			itemCategoryMap[resolvedItemID],
 			"uncategorized",
 		))
-		isSoldOut := boolValue(coalesce(obj["is_sold_out"], obj["sold_out"]))
+		availability := catalogitem.ResolveAvailability(obj)
+		imageURLs := catalogitem.ImageURLs(obj)
+		var imageURL any
+		if len(imageURLs) > 0 {
+			imageURL = imageURLs[0]
+		}
 
 		var formatted any
 		if value := formatAmount(amount, currency); value != nil {
@@ -489,8 +504,22 @@ func ExtractMenuItems(payload map[string]any, venueID string, venueSlug string) 
 			},
 			"option_group_ids": extractOptionGroupIDs(obj),
 			"category":         categoryName,
-			"is_sold_out":      isSoldOut,
-			"discounts":        discounts,
+			"is_available":     availability.IsAvailable,
+			"unavailable_reason": emptyToNil(
+				availability.Reason,
+			),
+			// Deprecated compatibility alias. The value is derived from the
+			// current Wolt disabled_info / purchasable_balance schema; raw
+			// is_sold_out and sold_out fields are no longer consulted.
+			"is_sold_out":           !availability.IsAvailable,
+			"purchasable_balance":   availability.PurchasableBalance,
+			"image_url":             imageURL,
+			"image_urls":            imageURLs,
+			"image_blurhash":        emptyToNil(catalogitem.ImageBlurhash(obj)),
+			"unit_info":             obj["unit_info"],
+			"unit_price":            obj["unit_price"],
+			"sell_by_weight_config": obj["sell_by_weight_config"],
+			"discounts":             discounts,
 		})
 	}
 

--- a/internal/service/observability/items_builders.go
+++ b/internal/service/observability/items_builders.go
@@ -53,12 +53,14 @@ func BuildVenueMenu(venueID string, payloads []map[string]any, category string, 
 			applyCampaignPriceFraction(basePrice, originalPrice, campaign.maxFraction)
 		}
 		row := map[string]any{
-			"item_id":     item["item_id"],
-			"name":        item["name"],
-			"base_price":  basePrice,
-			"discounts":   discountLabels,
-			"is_sold_out": boolValue(item["is_sold_out"]),
+			"item_id":      item["item_id"],
+			"name":         item["name"],
+			"base_price":   basePrice,
+			"discounts":    discountLabels,
+			"is_available": boolValue(item["is_available"]),
+			"is_sold_out":  boolValue(item["is_sold_out"]),
 		}
+		copyItemMetadata(row, item)
 		if intValue(originalPrice["amount"]) > 0 {
 			row["original_price"] = originalPrice
 		}
@@ -295,8 +297,9 @@ func BuildItemSearchResult(
 					"currency":         emptyToNil(item.Venue.Currency),
 					"formatted_amount": nil,
 				},
-				"category":    "venue",
-				"is_sold_out": false,
+				"category":     "venue",
+				"is_available": true,
+				"is_sold_out":  false,
 			})
 		}
 	}
@@ -328,7 +331,7 @@ func BuildItemSearchResult(
 	for _, item := range menuItems {
 		basePrice := normalizeBasePrice(toMap(item["base_price"]), fallbackCurrency)
 		originalPrice := normalizeBasePrice(toMap(item["original_price"]), fallbackCurrency)
-		rows = append(rows, map[string]any{
+		row := map[string]any{
 			"item_id":        item["item_id"],
 			"venue_id":       coalesce(item["venue_id"], ""),
 			"venue_slug":     coalesce(item["venue_slug"], ""),
@@ -337,8 +340,11 @@ func BuildItemSearchResult(
 			"original_price": originalPrice,
 			"discounts":      item["discounts"],
 			"currency":       basePrice["currency"],
+			"is_available":   boolValue(item["is_available"]),
 			"is_sold_out":    boolValue(item["is_sold_out"]),
-		})
+		}
+		copyItemMetadata(row, item)
+		rows = append(rows, row)
 	}
 
 	return map[string]any{
@@ -393,5 +399,25 @@ func BuildItemDetail(itemID string, venueID string, payload map[string]any, incl
 		"option_groups": extractOptionGroups(payload),
 		"upsell_items":  upsellItems,
 	}
+	copyItemMetadata(data, sourceItem)
 	return data, warnings
+}
+
+func copyItemMetadata(target map[string]any, source map[string]any) {
+	for _, key := range []string{
+		"is_available",
+		"unavailable_reason",
+		"is_sold_out",
+		"purchasable_balance",
+		"image_url",
+		"image_urls",
+		"image_blurhash",
+		"unit_info",
+		"unit_price",
+		"sell_by_weight_config",
+	} {
+		if value, exists := source[key]; exists {
+			target[key] = value
+		}
+	}
 }

--- a/internal/service/observability/observability_test.go
+++ b/internal/service/observability/observability_test.go
@@ -442,6 +442,53 @@ func TestExtractMenuItemsDerivesDiscountFromOriginalPrice(t *testing.T) {
 	}
 }
 
+func TestExtractMenuItemsUsesCurrentAvailabilityAndProductMetadata(t *testing.T) {
+	payload := map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":                  "item-1",
+				"name":                "Boneless chicken thigh",
+				"price":               1645,
+				"disabled_info":       map[string]any{"disable_text": "Sold out"},
+				"purchasable_balance": 0,
+				"unit_info":           "500 g",
+				"unit_price":          map[string]any{"price": 1645, "unit": "kilogram"},
+				"sell_by_weight_config": map[string]any{
+					"grams_per_step": 500,
+					"price_per_kg":   1645,
+				},
+				"images": []any{
+					map[string]any{
+						"url":      "https://imageproxy.wolt.com/assets/chicken",
+						"blurhash": "blur",
+					},
+				},
+			},
+		},
+	}
+
+	items := observability.ExtractMenuItems(payload, "venue-1", "venue-slug")
+	if len(items) != 1 {
+		t.Fatalf("expected one item, got %d", len(items))
+	}
+	item := items[0]
+	if available, _ := item["is_available"].(bool); available {
+		t.Fatalf("expected item to be unavailable: %#v", item)
+	}
+	if reason := item["unavailable_reason"]; reason != "Sold out" {
+		t.Fatalf("unavailable_reason = %v, want Sold out", reason)
+	}
+	if legacy, _ := item["is_sold_out"].(bool); !legacy {
+		t.Fatalf("expected compatibility is_sold_out alias to be true")
+	}
+	if imageURL := item["image_url"]; imageURL != "https://imageproxy.wolt.com/assets/chicken" {
+		t.Fatalf("image_url = %v", imageURL)
+	}
+	if unitInfo := item["unit_info"]; unitInfo != "500 g" {
+		t.Fatalf("unit_info = %v", unitInfo)
+	}
+}
+
 func TestBuildDiscoveryFeedDetectsWoltPlusFromIcon(t *testing.T) {
 	section := domain.Section{
 		Name:  "popular",

--- a/internal/service/payloadutil/payloadutil.go
+++ b/internal/service/payloadutil/payloadutil.go
@@ -3,8 +3,18 @@ package payloadutil
 import (
 	"fmt"
 	"reflect"
+	"regexp"
 	"strings"
 )
+
+var currencyCodePattern = regexp.MustCompile(`(?:^|[^A-Z])([A-Z]{3})(?:[^A-Z]|$)`)
+
+var knownCurrencies = map[string]struct{}{
+	"AED": {}, "AZN": {}, "BGN": {}, "CHF": {}, "CZK": {}, "DKK": {},
+	"EUR": {}, "GBP": {}, "GEL": {}, "HUF": {}, "ILS": {}, "ISK": {},
+	"JPY": {}, "KZT": {}, "NOK": {}, "PLN": {}, "RON": {}, "RSD": {},
+	"SEK": {}, "TRY": {}, "UAH": {}, "USD": {},
+}
 
 type OptionValueSpec struct {
 	ID    string
@@ -97,15 +107,79 @@ func InferCurrency(formatted string) string {
 		return ""
 	}
 	switch {
+	case strings.Contains(formatted, "₾"):
+		return "GEL"
 	case strings.Contains(formatted, "€"):
 		return "EUR"
+	case strings.Contains(formatted, "£"):
+		return "GBP"
 	case strings.Contains(formatted, "$"):
 		return "USD"
-	case strings.HasPrefix(formatted, "PLN"):
+	case strings.Contains(strings.ToLower(formatted), "zł"):
 		return "PLN"
-	default:
+	}
+	match := currencyCodePattern.FindStringSubmatch(strings.ToUpper(formatted))
+	if len(match) == 2 {
+		return NormalizeCurrency(match[1])
+	}
+	return ""
+}
+
+// NormalizeCurrency returns a supported uppercase ISO 4217 code or an empty
+// string. Restricting codes prevents ordinary three-letter words in formatted
+// labels from being mistaken for currencies.
+func NormalizeCurrency(value string) string {
+	code := strings.ToUpper(strings.TrimSpace(value))
+	if _, ok := knownCurrencies[code]; !ok {
 		return ""
 	}
+	return code
+}
+
+// CurrencyFromVenuePayload reads the explicit currency fields used by Wolt's
+// static and dynamic venue payloads.
+func CurrencyFromVenuePayload(payload map[string]any) string {
+	if payload == nil {
+		return ""
+	}
+	candidates := []any{
+		payload["currency"],
+		payload["currency_code"],
+	}
+	for _, key := range []string{"venue", "venue_raw"} {
+		venue := Map(payload[key])
+		candidates = append(candidates,
+			venue["currency"],
+			venue["currency_code"],
+			Map(venue["price"])["currency"],
+		)
+	}
+	for _, candidate := range candidates {
+		if currency := NormalizeCurrency(String(candidate)); currency != "" {
+			return currency
+		}
+	}
+	return ""
+}
+
+// CurrencyFromBasket prefers structured basket and venue currency fields, then
+// falls back to the formatted total.
+func CurrencyFromBasket(basket map[string]any) string {
+	if basket == nil {
+		return ""
+	}
+	venue := Map(basket["venue"])
+	for _, candidate := range []any{
+		basket["currency"],
+		Map(basket["total_price"])["currency"],
+		venue["currency"],
+		venue["currency_code"],
+	} {
+		if currency := NormalizeCurrency(String(candidate)); currency != "" {
+			return currency
+		}
+	}
+	return InferCurrency(String(basket["total"]))
 }
 
 func Map(value any) map[string]any {

--- a/internal/service/payloadutil/payloadutil_test.go
+++ b/internal/service/payloadutil/payloadutil_test.go
@@ -115,6 +115,13 @@ func TestInferCurrency(t *testing.T) {
 		{"$9.99", "USD"},
 		{"PLN 20", "PLN"},
 		{"  €5 ", "EUR"},
+		{"GEL0.00", "GEL"},
+		{"GEL 16.45", "GEL"},
+		{"₾16.45", "GEL"},
+		{"SEK 149.00", "SEK"},
+		{"149,00 DKK", "DKK"},
+		{"NOK129.00", "NOK"},
+		{"the total", ""},
 		{"12.50", ""}, // no recognizable symbol
 		{"", ""},
 	}

--- a/test/e2e/cli_all_commands_test.go
+++ b/test/e2e/cli_all_commands_test.go
@@ -1113,8 +1113,8 @@ func TestVenueMenuSupportsPageSortAndFilters(t *testing.T) {
 	}
 	assortmentPayload := map[string]any{
 		"items": []any{
-			map[string]any{"id": "item-a", "name": "Alpha", "price": 700, "is_sold_out": false, "promotions": []any{"20% off"}},
-			map[string]any{"id": "item-b", "name": "Beta", "price": 900, "is_sold_out": false, "promotions": []any{"10% off"}},
+			map[string]any{"id": "item-a", "name": "Alpha", "price": 700, "disabled_info": nil, "promotions": []any{"20% off"}},
+			map[string]any{"id": "item-b", "name": "Beta", "price": 900, "disabled_info": nil, "promotions": []any{"10% off"}},
 		},
 	}
 
@@ -1466,16 +1466,17 @@ func TestVenueSearchScopedByVenue(t *testing.T) {
 				"name":             "Milk 1L",
 				"price":            map[string]any{"amount": 199, "currency": "EUR"},
 				"category_name":    "Dairy",
-				"is_sold_out":      false,
+				"disabled_info":    nil,
 				"promotions":       []any{"10% off"},
 				"option_group_ids": []any{"opt-1"},
 			},
 			map[string]any{
-				"id":            "item-2",
-				"name":          "Bread",
-				"price":         map[string]any{"amount": 249, "currency": "EUR"},
-				"category_name": "Bakery",
-				"is_sold_out":   true,
+				"id":                  "item-2",
+				"name":                "Bread",
+				"price":               map[string]any{"amount": 249, "currency": "EUR"},
+				"category_name":       "Bakery",
+				"disabled_info":       map[string]any{"disable_text": "Sold out"},
+				"purchasable_balance": 0,
 			},
 		},
 	}

--- a/test/e2e/cli_cart_profile_test.go
+++ b/test/e2e/cli_cart_profile_test.go
@@ -731,6 +731,16 @@ func TestCartAddUsesVenueSlugAssortmentFallback(t *testing.T) {
 			venueItemPageFunc: func(context.Context, string, string) (map[string]any, error) {
 				return nil, errors.New("item endpoint unavailable")
 			},
+			assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+				return map[string]any{"items": []any{
+					map[string]any{
+						"id":                  "item-1",
+						"name":                "Classics set",
+						"price":               1700,
+						"purchasable_balance": 10,
+					},
+				}}, nil
+			},
 			restaurantByIDFunc: func(context.Context, string) (*domain.Restaurant, error) {
 				return nil, errors.New("restaurant endpoint unavailable")
 			},
@@ -1003,6 +1013,61 @@ func TestCartAddRejectsUnresolvedVenue(t *testing.T) {
 	}
 }
 
+func TestCartAddBlocksUnavailableItemEvenWithOverrides(t *testing.T) {
+	const venueID = "5f9a1b2c3d4e5f6071829304"
+	const itemID = "627cb2c7e2a6f0a1b2c3d4e5"
+	addCalled := false
+	deps := cli.Dependencies{
+		Wolt: &mockWolt{
+			venuePageStaticFunc: func(context.Context, string) (map[string]any, error) {
+				return map[string]any{"venue": map[string]any{"id": venueID, "currency": "GEL"}}, nil
+			},
+			assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+				return map[string]any{"items": []any{
+					map[string]any{
+						"id":                  itemID,
+						"name":                "Chicken thigh",
+						"disabled_info":       map[string]any{"disable_text": "Sold out"},
+						"purchasable_balance": 0,
+					},
+				}}, nil
+			},
+			addToBasketFunc: func(context.Context, map[string]any, woltgateway.AuthContext) (map[string]any, error) {
+				addCalled = true
+				return map[string]any{}, nil
+			},
+		},
+		Profiles: &mockProfiles{profile: domain.Profile{
+			Name: "default", IsDefault: true, Location: domain.Location{Lat: 41.7, Lon: 44.8},
+		}},
+		Location: &mockLocation{},
+		Config:   &mockConfig{},
+		Version:  "1.1.1",
+	}
+
+	exitCode, out := runCLIWithDeps(
+		t,
+		deps,
+		"cart", "add",
+		"test-venue",
+		itemID,
+		"--price", "1645",
+		"--currency", "GEL",
+		"--name", "Chicken thigh",
+		"--wtoken", "token",
+		"--format", "json",
+	)
+	if exitCode == 0 {
+		t.Fatalf("expected unavailable item to be rejected; output:\n%s", out)
+	}
+	if !strings.Contains(out, "WOLT_ITEM_UNAVAILABLE") || !strings.Contains(out, "Sold out") {
+		t.Fatalf("expected availability error, got:\n%s", out)
+	}
+	if addCalled {
+		t.Fatal("AddToBasket must not be called when the exact current item is unavailable")
+	}
+}
+
 func TestCartRemoveJSON(t *testing.T) {
 	seenPayload := map[string]any{}
 	deps := cli.Dependencies{
@@ -1171,7 +1236,7 @@ func TestCheckoutPreviewJSON(t *testing.T) {
 						map[string]any{
 							"id":    "basket-1",
 							"total": "€17.00",
-							"venue": map[string]any{"id": "venue-1", "country": "FIN"},
+							"venue": map[string]any{"id": "venue-1", "country": "FIN", "slug": "venue-1-slug"},
 							"items": []any{
 								map[string]any{
 									"id":    "item-1",
@@ -1373,7 +1438,7 @@ func TestCheckoutPreviewFallsBackCategoryToItemID(t *testing.T) {
 						map[string]any{
 							"id":    "basket-1",
 							"total": "€17.00",
-							"venue": map[string]any{"id": "venue-1", "country": "FIN"},
+							"venue": map[string]any{"id": "venue-1", "country": "FIN", "slug": "venue-1-slug"},
 							"items": []any{
 								map[string]any{
 									"id":      "693f837c465e0fe77eef4630",
@@ -1443,7 +1508,7 @@ func TestCheckoutPreviewMultipleBasketsSelectionWarning(t *testing.T) {
 						map[string]any{
 							"id":    "basket-1",
 							"total": "€17.00",
-							"venue": map[string]any{"id": "venue-1", "country": "FIN"},
+							"venue": map[string]any{"id": "venue-1", "country": "FIN", "slug": "venue-1-slug"},
 							"items": []any{
 								map[string]any{"id": "item-1", "count": 1, "price": 1700, "options": []any{}},
 							},
@@ -1451,7 +1516,7 @@ func TestCheckoutPreviewMultipleBasketsSelectionWarning(t *testing.T) {
 						map[string]any{
 							"id":    "basket-2",
 							"total": "€12.00",
-							"venue": map[string]any{"id": "venue-2", "country": "FIN"},
+							"venue": map[string]any{"id": "venue-2", "country": "FIN", "slug": "venue-2-slug"},
 							"items": []any{
 								map[string]any{"id": "item-2", "count": 1, "price": 1200, "options": []any{}},
 							},

--- a/test/e2e/cli_parity_test.go
+++ b/test/e2e/cli_parity_test.go
@@ -126,7 +126,21 @@ func (m *mockWolt) AssortmentItemsByVenueSlug(
 	auth woltgateway.AuthContext,
 ) (map[string]any, error) {
 	if m.assortmentItemsFn == nil {
-		return nil, errors.New("assortment items by venue slug not mocked")
+		// Authenticated cart/checkout tests pass the stable fixture token
+		// explicitly. Read-only item tests intentionally keep the endpoint
+		// unmocked so their item-page fixtures remain authoritative.
+		if auth.WToken != "token" {
+			return nil, errors.New("assortment items by venue slug not mocked")
+		}
+		items := make([]any, 0, len(itemIDs))
+		for _, itemID := range itemIDs {
+			items = append(items, map[string]any{
+				"id":                  itemID,
+				"name":                itemID,
+				"purchasable_balance": 10,
+			})
+		}
+		return map[string]any{"items": items}, nil
 	}
 	return m.assortmentItemsFn(ctx, slug, itemIDs, auth)
 }


### PR DESCRIPTION
## Summary

- derive current availability from Wolt's `disabled_info` and `purchasable_balance` fields while retaining `is_sold_out` only as a deprecated derived alias
- revalidate exact current items before cart add and checkout preview, failing closed on missing/unavailable items; public catalog reads retry anonymously when saved auth is rejected
- expose image URLs and unit/weight metadata in normalized menu and item detail output
- resolve basket/checkout currency from structured item, basket, or venue metadata (including GEL) instead of silently defaulting to EUR

## Evidence

Current consumer-assortment payloads and the Wolt web client use a non-null `disabled_info` as the enabled/disabled switch, with `purchasable_balance` as an inventory guard. A read-only live check against Biu Biu item `7a1d44973a3006ece90fb067` returned `disabled_info: Sold out`, `purchasable_balance: 0`, a GEL price, and a working product image URL.

## Validation

- `go mod download`
- `go build ./...`
- `go vet ./...`
- `golangci-lint v2.4.0`: 0 issues
- focused service, CLI, MCP, and e2e tests pass
- read-only live check: unavailable status, `GEL 16.45`, and image URL verified (HTTP 200)

Native Windows full-suite limitations are pre-existing platform assumptions: HOME precedence, Unix `0600` permissions, an `echo` executable, and an e2e subprocess path without the `.exe` suffix. `go test -race` also requires a Windows CGO toolchain. GitHub Actions on Ubuntu remains the authoritative full test/race run.