### PR TITLE
Fix weighted item pricing in cart and checkout

### DIFF
--- a/internal/cli/cart_checkout_contract_test.go
+++ b/internal/cli/cart_checkout_contract_test.go
@@ -158,6 +158,69 @@ func TestCartAddRejectsUnidentifiableExistingBasket(t *testing.T) {
 	}
 }
 
+func TestCartAddSendsWeightedBasketPayload(t *testing.T) {
+	var captured map[string]any
+	api := &testWoltAPI{
+		venuePageStaticFn: func(context.Context, string) (map[string]any, error) {
+			return syntheticVenuePayload(), nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  regressionItemID,
+					"name":                "Synthetic weighted item",
+					"price":               1645,
+					"purchasable_balance": 10,
+					"sell_by_weight_config": map[string]any{
+						"input_type":     "grams",
+						"grams_per_step": 500,
+						"price_per_kg":   1645,
+					},
+				},
+			}}, nil
+		},
+		addToBasketFn: func(_ context.Context, payload map[string]any, _ woltgateway.AuthContext) (map[string]any, error) {
+			captured = payload
+			return map[string]any{"id": "basket-synthetic"}, nil
+		},
+	}
+	output, err := runCLIRegressionCommand(
+		t,
+		newCartAddCommand(regressionCLIDeps(api)),
+		regressionVenueSlug,
+		regressionItemID,
+		"--format", "json",
+	)
+	if err != nil {
+		t.Fatalf("cart add failed: %v\n%s", err, output.String())
+	}
+	item := asMap(asSlice(captured["items"])[0])
+	info := asMap(item["weighted_item_info"])
+	if asInt(item["count"]) != 1 || asInt(item["price"]) != 823 ||
+		asInt(info["purchased_weight_in_grams"]) != 500 ||
+		asString(info["weighted_item_input_type"]) != "grams" {
+		t.Fatalf("AddToBasket weighted item = %#v", item)
+	}
+	if _, exists := item["is_weighted_item"]; exists {
+		t.Fatal("basket payload contains checkout-only is_weighted_item")
+	}
+}
+
+func TestBasketLineConfiguredTotalUsesWeightedPriceAsLineTotal(t *testing.T) {
+	total, err := basketLineConfiguredTotal(map[string]any{
+		"count": 2,
+		"price": 1600,
+		"weighted_item_info": map[string]any{
+			"count":                     2,
+			"purchased_weight_in_grams": 400,
+			"weighted_item_input_type":  "number_of_items",
+		},
+	})
+	if err != nil || total != 1600 {
+		t.Fatalf("weighted configured total = %d, %v; want 1600", total, err)
+	}
+}
+
 func TestCartClearUsesBothContainersAndCompatibilityIDs(t *testing.T) {
 	deletedIDs := []string{}
 	api := &testWoltAPI{

--- a/internal/cli/commands_cart.go
+++ b/internal/cli/commands_cart.go
@@ -574,19 +574,21 @@ func newCartAddCommand(deps Dependencies) *cobra.Command {
 			}
 
 			mergedItems := []any{newLineItem}
-			if selectedBasket != nil {
+			if weightConfig, weighted := payloadutil.WeightConfigFromItem(itemPayload); weighted {
+				mergedItems, err = payloadutil.MergeWeightedBasketItems(selectedBasket, itemID, count, newLineItem, weightConfig)
+			} else if selectedBasket != nil {
 				mergedItems, err = payloadutil.MergeBasketItems(selectedBasket, itemID, count, newLineItem)
-				if err != nil {
-					return emitError(
-						cmd,
-						format,
-						profile,
-						flags.Locale,
-						flags.Output,
-						"WOLT_INVALID_BASKET",
-						err.Error()+"; the item was not added.",
-					)
-				}
+			}
+			if err != nil {
+				return emitError(
+					cmd,
+					format,
+					profile,
+					flags.Locale,
+					flags.Output,
+					"WOLT_INVALID_BASKET",
+					err.Error()+"; the item was not added.",
+				)
 			}
 			if currency == "" {
 				return emitError(
@@ -1539,6 +1541,9 @@ func basketItemsSubtotal(items []any) (int, error) {
 
 func basketLineConfiguredTotal(item map[string]any) (int, error) {
 	count := basketLineCount(item)
+	if asMap(item["weighted_item_info"]) != nil {
+		count = 1
+	}
 	unitAmount := payloadutil.MinorAmount(item["price"])
 	for _, rawOption := range asSlice(item["options"]) {
 		option := asMap(rawOption)

--- a/internal/mcpserver/cart_checkout_contract_test.go
+++ b/internal/mcpserver/cart_checkout_contract_test.go
@@ -95,6 +95,59 @@ func TestCartAddRejectsUnidentifiableExistingBasket(t *testing.T) {
 	}
 }
 
+func TestCartAddSendsWeightedBasketPayload(t *testing.T) {
+	const (
+		venueID = "000000000000000000000351"
+		itemID  = "000000000000000000000352"
+	)
+	var captured map[string]any
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{
+				"venue": map[string]any{"id": venueID, "slug": "synthetic-market", "currency": "GEL"},
+			}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Synthetic weighted item",
+					"price":               1645,
+					"purchasable_balance": 10,
+					"sell_by_weight_config": map[string]any{
+						"input_type":     "grams",
+						"grams_per_step": 500,
+						"price_per_kg":   1645,
+					},
+				},
+			}}, nil
+		},
+		addToBasketFn: func(_ context.Context, payload map[string]any, _ woltgateway.AuthContext) (map[string]any, error) {
+			captured = payload
+			return map[string]any{"id": "basket-synthetic"}, nil
+		},
+	}
+	tc := regressionMCPToolCtx(wolt)
+
+	_, _, err := tc.handleCartAdd(context.Background(), nil, CartAddInput{
+		Venue:  "synthetic-market",
+		ItemID: itemID,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	item := payloadutil.Map(payloadutil.Slice(captured["items"])[0])
+	info := payloadutil.Map(item["weighted_item_info"])
+	if item["count"] != 1 || item["price"] != 823 ||
+		info["purchased_weight_in_grams"] != 500 ||
+		info["weighted_item_input_type"] != "grams" {
+		t.Fatalf("AddToBasket weighted item = %#v", item)
+	}
+	if _, exists := item["is_weighted_item"]; exists {
+		t.Fatal("basket payload contains checkout-only is_weighted_item")
+	}
+}
+
 func TestCartAddRejectsRequiredOptionsItCannotRepresent(t *testing.T) {
 	const (
 		venueID = "000000000000000000000343"

--- a/internal/mcpserver/tools_cart.go
+++ b/internal/mcpserver/tools_cart.go
@@ -291,11 +291,13 @@ func (tc *ToolCtx) handleCartAdd(ctx context.Context, _ *mcp.CallToolRequest, in
 	}
 
 	mergedItems := []any{newLine}
-	if existingBasket != nil {
+	if weightConfig, weighted := payloadutil.WeightConfigFromItem(itemPayload); weighted {
+		mergedItems, err = payloadutil.MergeWeightedBasketItems(existingBasket, in.ItemID, count, newLine, weightConfig)
+	} else if existingBasket != nil {
 		mergedItems, err = payloadutil.MergeBasketItems(existingBasket, in.ItemID, count, newLine)
-		if err != nil {
-			return nil, CartAddOutput{}, toolErrf("item was NOT added: %v", err)
-		}
+	}
+	if err != nil {
+		return nil, CartAddOutput{}, toolErrf("item was NOT added: %v", err)
 	}
 	if currency == "" {
 		currency = resolveVenueCurrency(ctx, tc, ref, existingBasket, currentAssortment, itemPayload)

--- a/internal/service/checkoutpayload/checkoutpayload.go
+++ b/internal/service/checkoutpayload/checkoutpayload.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/mekedron/wolt-cli/internal/domain"
 	woltgateway "github.com/mekedron/wolt-cli/internal/gateway/wolt"
+	"github.com/mekedron/wolt-cli/internal/service/catalogitem"
 	"github.com/mekedron/wolt-cli/internal/service/payloadutil"
 )
 
@@ -122,14 +123,30 @@ func Build(
 		if !ok {
 			return nil, warnings, fmt.Errorf("basket item %q total exceeds the supported integer range", itemID)
 		}
+		basePrice := price
+		isWeighted := false
+		catalogItem := catalogitem.Find(assortmentPayload, itemID)
+		if catalogItem == nil {
+			catalogItem = catalogitem.Find(detail, itemID)
+		}
+		if weightConfig, weighted := payloadutil.WeightConfigFromItem(catalogItem); weighted {
+			values, valuesErr := weightConfig.ValuesFromBasket(item)
+			if valuesErr != nil {
+				return nil, warnings, fmt.Errorf("basket item %q: %w", itemID, valuesErr)
+			}
+			count = values.Count
+			basePrice = weightConfig.PricePerKilogram
+			endAmount = values.Price
+			isWeighted = true
+		}
 
 		menuItems = append(menuItems, map[string]any{
 			"id":                                itemID,
 			"venue_id":                          venueID,
 			"count":                             count,
-			"base_price":                        price,
+			"base_price":                        basePrice,
 			"end_amount":                        endAmount,
-			"is_weighted_item":                  false,
+			"is_weighted_item":                  isWeighted,
 			"category_id":                       categoryID,
 			"category_ids":                      categoryIDs,
 			"alcohol_permille":                  payloadutil.Int(payloadutil.CoalesceAny(item["alcohol_permille"], 0)),

--- a/internal/service/checkoutpayload/checkoutpayload_test.go
+++ b/internal/service/checkoutpayload/checkoutpayload_test.go
@@ -170,6 +170,55 @@ func TestBuildProducesPurchasePlanShape(t *testing.T) {
 	}
 }
 
+func TestBuildUsesCatalogWeightForCheckoutItem(t *testing.T) {
+	const itemID = "000000000000000000000411"
+	basket := basketWithItem("GEL 8.23", map[string]any{
+		"id":          itemID,
+		"count":       1,
+		"price":       1645,
+		"category_id": "synthetic-category",
+		"weighted_item_info": map[string]any{
+			"count":                     1,
+			"purchased_weight_in_grams": 500,
+		},
+	})
+	basket["venue"].(map[string]any)["slug"] = "synthetic-market"
+	basket["venue"].(map[string]any)["currency"] = "GEL"
+	api := &fakeAPI{
+		assortmentFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id": itemID,
+					"sell_by_weight_config": map[string]any{
+						"input_type":     "grams",
+						"grams_per_step": 500,
+						"price_per_kg":   1645,
+					},
+				},
+			}}, nil
+		},
+	}
+
+	payload, warnings, err := Build(
+		context.Background(),
+		api,
+		nil,
+		basket,
+		domain.Location{},
+		"standard",
+		0,
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Build() error = %v (warnings: %v)", err, warnings)
+	}
+	item := firstMenuItem(t, purchasePlan(t, payload))
+	if item["count"] != 1 || item["base_price"] != 1645 ||
+		item["end_amount"] != 823 || item["is_weighted_item"] != true {
+		t.Fatalf("weighted checkout item = %#v", item)
+	}
+}
+
 func TestBuildCheckoutOptionsOnlyOverridesKnownDetailPrices(t *testing.T) {
 	raw := []any{
 		map[string]any{

--- a/internal/service/payloadutil/payloadutil.go
+++ b/internal/service/payloadutil/payloadutil.go
@@ -359,7 +359,7 @@ func BuildBasketUpsertItem(line map[string]any, count int) (map[string]any, erro
 		}
 	}
 
-	return map[string]any{
+	item := map[string]any{
 		"id":      itemID,
 		"count":   count,
 		"name":    String(line["name"]),
@@ -368,7 +368,27 @@ func BuildBasketUpsertItem(line map[string]any, count int) (map[string]any, erro
 		"substitution_settings": map[string]any{
 			"is_allowed": allowSubstitutions,
 		},
-	}, nil
+	}
+	if info := basketWeightedItemInfo(line); info != nil {
+		item["weighted_item_info"] = info
+	}
+	return item, nil
+}
+
+func basketWeightedItemInfo(line map[string]any) map[string]any {
+	info := Map(line["weighted_item_info"])
+	inputType := strings.TrimSpace(String(info["weighted_item_input_type"]))
+	count := Int(info["count"])
+	grams := Int(info["purchased_weight_in_grams"])
+	if count <= 0 || grams <= 0 ||
+		(inputType != WeightedInputGrams && inputType != WeightedInputNumberOfItems) {
+		return nil
+	}
+	return map[string]any{
+		"count":                     count,
+		"purchased_weight_in_grams": grams,
+		"weighted_item_input_type":  inputType,
+	}
 }
 
 // MergeBasketItems preserves every existing line while adding or incrementing
@@ -455,6 +475,9 @@ func RemoveBasketItems(basket map[string]any, itemID string, count int) ([]any, 
 				remainingCount -= lineCount
 			}
 			continue
+		}
+		if basketWeightedItemInfo(line) != nil {
+			return nil, 0, fmt.Errorf("weighted item %q cannot be partially removed without current catalog pricing", target)
 		}
 		nextRemoved, ok := CheckedAddInt(removed, remainingCount)
 		if !ok {

--- a/internal/service/payloadutil/weighted.go
+++ b/internal/service/payloadutil/weighted.go
@@ -1,0 +1,192 @@
+package payloadutil
+
+import (
+	"fmt"
+	"strings"
+)
+
+const (
+	WeightedInputGrams         = "grams"
+	WeightedInputNumberOfItems = "number_of_items"
+)
+
+// WeightConfig is the pricing information Wolt publishes for a weighted item.
+type WeightConfig struct {
+	InputType        string
+	GramsPerStep     int
+	PricePerKilogram int
+}
+
+// WeightedValues are the basket and checkout values for a selected weight.
+type WeightedValues struct {
+	Count int
+	Grams int
+	Price int
+}
+
+// WeightConfigFromItem returns a usable weighted-item configuration.
+func WeightConfigFromItem(item map[string]any) (WeightConfig, bool) {
+	raw := Map(item["sell_by_weight_config"])
+	config := WeightConfig{
+		InputType:        strings.TrimSpace(String(raw["input_type"])),
+		GramsPerStep:     Int(raw["grams_per_step"]),
+		PricePerKilogram: Int(raw["price_per_kg"]),
+	}
+	if config.InputType != WeightedInputGrams &&
+		config.InputType != WeightedInputNumberOfItems {
+		return WeightConfig{}, false
+	}
+	if config.GramsPerStep <= 0 || config.PricePerKilogram <= 0 {
+		return WeightConfig{}, false
+	}
+	return config, true
+}
+
+// ValuesForSteps converts the quantity accepted by cart add into Wolt's
+// weighted basket values. For gram input, one step is grams_per_step.
+func (config WeightConfig) ValuesForSteps(steps int) (WeightedValues, error) {
+	if steps <= 0 {
+		return WeightedValues{}, fmt.Errorf("weighted item count must be greater than zero")
+	}
+	grams, ok := CheckedMultiplyInt(config.GramsPerStep, steps)
+	if !ok {
+		return WeightedValues{}, fmt.Errorf("weighted item amount exceeds the supported integer range")
+	}
+	count := steps
+	if config.InputType == WeightedInputGrams {
+		count = 1
+	}
+	return config.values(count, grams)
+}
+
+// ValuesFromBasket reads an existing weighted selection. Older basket lines
+// may omit the input type, so the current catalog config remains authoritative.
+func (config WeightConfig) ValuesFromBasket(line map[string]any) (WeightedValues, error) {
+	info := Map(line["weighted_item_info"])
+	grams := Int(info["purchased_weight_in_grams"])
+	steps := Int(info["count"])
+	if steps <= 0 {
+		steps = Int(line["count"])
+	}
+	if steps <= 0 {
+		steps = 1
+	}
+	if grams <= 0 {
+		var ok bool
+		grams, ok = CheckedMultiplyInt(config.GramsPerStep, steps)
+		if !ok {
+			return WeightedValues{}, fmt.Errorf("weighted item amount exceeds the supported integer range")
+		}
+	}
+	count := steps
+	if config.InputType == WeightedInputGrams {
+		count = 1
+	}
+	return config.values(count, grams)
+}
+
+func (config WeightConfig) values(count, grams int) (WeightedValues, error) {
+	if count <= 0 || grams <= 0 {
+		return WeightedValues{}, fmt.Errorf("weighted item amount must be greater than zero")
+	}
+	product, ok := CheckedMultiplyInt(config.PricePerKilogram, grams)
+	if !ok {
+		return WeightedValues{}, fmt.Errorf("weighted item price exceeds the supported integer range")
+	}
+	product, ok = CheckedAddInt(product, 500)
+	if !ok {
+		return WeightedValues{}, fmt.Errorf("weighted item price exceeds the supported integer range")
+	}
+	return WeightedValues{Count: count, Grams: grams, Price: product / 1000}, nil
+}
+
+func (config WeightConfig) itemInfo(values WeightedValues) map[string]any {
+	return map[string]any{
+		"count":                     values.Count,
+		"purchased_weight_in_grams": values.Grams,
+		"weighted_item_input_type":  config.InputType,
+	}
+}
+
+// BuildWeightedBasketItem builds the exact compact weighted line accepted by
+// Wolt's basket endpoint.
+func BuildWeightedBasketItem(line map[string]any, steps int, config WeightConfig) (map[string]any, error) {
+	values, err := config.ValuesForSteps(steps)
+	if err != nil {
+		return nil, err
+	}
+	copy := make(map[string]any, len(line)+2)
+	for key, value := range line {
+		copy[key] = value
+	}
+	copy["count"] = values.Count
+	copy["price"] = values.Price
+	copy["weighted_item_info"] = config.itemInfo(values)
+	return BuildBasketUpsertItem(copy, values.Count)
+}
+
+// MergeWeightedBasketItems preserves the complete basket replacement while
+// increasing one weighted selection.
+func MergeWeightedBasketItems(
+	basket map[string]any,
+	addedItemID string,
+	addedSteps int,
+	newLine map[string]any,
+	config WeightConfig,
+) ([]any, error) {
+	replacement, err := BuildWeightedBasketItem(newLine, addedSteps, config)
+	if err != nil {
+		return nil, err
+	}
+	if basket == nil {
+		return []any{replacement}, nil
+	}
+	existing, err := basketReplacementItems(basket)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]any, 0, len(existing)+1)
+	for index, line := range existing {
+		if !strings.EqualFold(strings.TrimSpace(String(line["id"])), strings.TrimSpace(addedItemID)) ||
+			!basketLineConfigurationEqual(line, replacement) {
+			out = append(out, line)
+			continue
+		}
+		current, valuesErr := config.ValuesFromBasket(line)
+		if valuesErr != nil {
+			return nil, valuesErr
+		}
+		added, valuesErr := config.ValuesForSteps(addedSteps)
+		if valuesErr != nil {
+			return nil, valuesErr
+		}
+		if config.InputType == WeightedInputGrams {
+			grams, ok := CheckedAddInt(current.Grams, added.Grams)
+			if !ok {
+				return nil, fmt.Errorf("weighted item amount exceeds the supported integer range")
+			}
+			values, valuesErr := config.values(1, grams)
+			if valuesErr != nil {
+				return nil, valuesErr
+			}
+			replacement["count"] = values.Count
+			replacement["price"] = values.Price
+			replacement["weighted_item_info"] = config.itemInfo(values)
+		} else {
+			steps, ok := CheckedAddInt(current.Count, addedSteps)
+			if !ok {
+				return nil, fmt.Errorf("weighted item count exceeds the supported integer range")
+			}
+			replacement, valuesErr = BuildWeightedBasketItem(newLine, steps, config)
+			if valuesErr != nil {
+				return nil, valuesErr
+			}
+		}
+		out = append(out, replacement)
+		for _, trailing := range existing[index+1:] {
+			out = append(out, trailing)
+		}
+		return out, nil
+	}
+	return append(out, replacement), nil
+}

--- a/internal/service/payloadutil/weighted_test.go
+++ b/internal/service/payloadutil/weighted_test.go
@@ -1,0 +1,112 @@
+package payloadutil
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestBuildWeightedBasketItemUsesSelectedWeightPrice(t *testing.T) {
+	config, ok := WeightConfigFromItem(map[string]any{
+		"sell_by_weight_config": map[string]any{
+			"input_type":     "grams",
+			"grams_per_step": 500,
+			"price_per_kg":   1645,
+		},
+	})
+	if !ok {
+		t.Fatal("WeightConfigFromItem() did not recognize a valid config")
+	}
+
+	item, err := BuildWeightedBasketItem(map[string]any{
+		"id":      "000000000000000000000401",
+		"name":    "Synthetic weighted item",
+		"price":   1645,
+		"options": []any{},
+	}, 1, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantInfo := map[string]any{
+		"count":                     1,
+		"purchased_weight_in_grams": 500,
+		"weighted_item_input_type":  "grams",
+	}
+	if item["count"] != 1 || item["price"] != 823 ||
+		!reflect.DeepEqual(item["weighted_item_info"], wantInfo) {
+		t.Fatalf("weighted basket item = %#v", item)
+	}
+	if _, exists := item["is_weighted_item"]; exists {
+		t.Fatal("basket item contains checkout-only is_weighted_item")
+	}
+}
+
+func TestWeightedValuesSupportNumberOfItems(t *testing.T) {
+	config := WeightConfig{
+		InputType:        WeightedInputNumberOfItems,
+		GramsPerStep:     200,
+		PricePerKilogram: 3999,
+	}
+	values, err := config.ValuesForSteps(2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if values != (WeightedValues{Count: 2, Grams: 400, Price: 1600}) {
+		t.Fatalf("ValuesForSteps(2) = %#v", values)
+	}
+}
+
+func TestMergeWeightedBasketItemsRepairsLegacyLine(t *testing.T) {
+	config := WeightConfig{
+		InputType:        WeightedInputGrams,
+		GramsPerStep:     500,
+		PricePerKilogram: 1645,
+	}
+	basket := map[string]any{"items": []any{
+		map[string]any{
+			"id":    "000000000000000000000401",
+			"count": 1,
+			"name":  "Old snapshot",
+			"price": 1645,
+			"weighted_item_info": map[string]any{
+				"count":                     1,
+				"purchased_weight_in_grams": 500,
+			},
+		},
+		map[string]any{"id": "000000000000000000000402", "count": 1, "price": 250},
+	}}
+	items, err := MergeWeightedBasketItems(
+		basket,
+		"000000000000000000000401",
+		1,
+		map[string]any{"id": "000000000000000000000401", "name": "Current item", "price": 1645},
+		config,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	weighted := Map(items[0])
+	info := Map(weighted["weighted_item_info"])
+	if len(items) != 2 || weighted["count"] != 1 || weighted["price"] != 1645 ||
+		info["purchased_weight_in_grams"] != 1000 ||
+		String(Map(items[1])["id"]) != "000000000000000000000402" {
+		t.Fatalf("merged basket items = %#v", items)
+	}
+}
+
+func TestRemoveBasketItemsRejectsPartialWeightedRemoval(t *testing.T) {
+	basket := map[string]any{"items": []any{
+		map[string]any{
+			"id":    "000000000000000000000403",
+			"count": 2,
+			"price": 1600,
+			"weighted_item_info": map[string]any{
+				"count":                     2,
+				"purchased_weight_in_grams": 400,
+				"weighted_item_input_type":  "number_of_items",
+			},
+		},
+	}}
+	if _, _, err := RemoveBasketItems(basket, "000000000000000000000403", 1); err == nil {
+		t.Fatal("partial weighted removal succeeded without current catalog pricing")
+	}
+}


### PR DESCRIPTION
## Summary

- calculate selected weight and price from `sell_by_weight_config` for both `grams` and `number_of_items`
- send Wolt-compatible `weighted_item_info`, basket count, and selected-weight price from CLI and MCP cart add
- preserve valid weighted metadata when rebuilding complete basket replacement payloads
- build weighted checkout items with the catalog price per kilogram, selected-weight `end_amount`, and `is_weighted_item`
- treat a weighted basket price as the complete line price in local subtotal fallback calculations
- fail closed on partial weighted-item removal when current catalog pricing is unavailable

## Root cause

Cart mutations treated every catalog item as a fixed-price unit. For weighted items this dropped `weighted_item_info` and sent the price per kilogram as the selected item price.

Checkout also marked every item as non-weighted and calculated `end_amount` as `count * basket price`. This produces an incorrect subtotal for weight selections. For example, 500 g at GEL 16.45/kg must be GEL 8.23 after Wolt-compatible rounding, not GEL 16.45.

## Implementation

The weighted-item calculation is implemented once in `payloadutil` and shared by CLI cart add, MCP cart add, and checkout payload construction.

The read-only cart path remains unchanged: it does not mutate upstream responses or make additional assortment requests.

The checkout preview API does not expose an exact authorization reserve, so this change does not derive one from a market-specific or assumed percentage.

## Validation

- `go mod download`
- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- `golangci-lint v2.4.0 run` — 0 issues
- read-only live cart check: 500 g item subtotal is GEL 8.23
- read-only live checkout check: item subtotal is GEL 8.23