### PR TITLE
fix(checkout): reuse validated catalog categories

### DIFF
--- a/internal/cli/cart_checkout_contract_test.go
+++ b/internal/cli/cart_checkout_contract_test.go
@@ -122,6 +122,76 @@ func TestCheckoutNegativeTipFailsBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestCheckoutUsesValidatedCatalogCategoryWhenBasketOmitsIt(t *testing.T) {
+	assortmentItemCalls := 0
+	var captured map[string]any
+	api := &testWoltAPI{
+		venuePageStaticFn: func(context.Context, string) (map[string]any, error) {
+			return syntheticVenuePayload(), nil
+		},
+		basketsPageFn: func(context.Context, domain.Location, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"baskets": []any{
+				map[string]any{
+					"id": "basket-category-regression",
+					"venue": map[string]any{
+						"id":       regressionVenueID,
+						"slug":     regressionVenueSlug,
+						"currency": "GEL",
+					},
+					"total": "GEL 12.50",
+					"items": []any{
+						map[string]any{
+							"id":    regressionItemID,
+							"name":  "Catalog-only category item",
+							"count": 1,
+							"price": 1250,
+						},
+					},
+				},
+			}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			assortmentItemCalls++
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  regressionItemID,
+					"name":                "Catalog-only category item",
+					"price":               1250,
+					"category_id":         "hardware-category",
+					"purchasable_balance": 1,
+				},
+			}}, nil
+		},
+		checkoutPreviewFn: func(_ context.Context, payload map[string]any, _ woltgateway.AuthContext) (map[string]any, error) {
+			captured = payload
+			return map[string]any{
+				"payable_amount": 1250,
+				"delivery_configs": []any{
+					map[string]any{"type": "standard", "selected": true},
+				},
+			}, nil
+		},
+	}
+
+	output, err := runCLIRegressionCommand(
+		t,
+		newCheckoutPreviewCommand(regressionCLIDeps(api)),
+		"--venue-id", regressionVenueID,
+		"--format", "json",
+	)
+	if err != nil {
+		t.Fatalf("checkout preview failed: %v\n%s", err, output.String())
+	}
+	if assortmentItemCalls != 1 {
+		t.Fatalf("current-item lookup calls = %d, want 1", assortmentItemCalls)
+	}
+	plan := asMap(captured["purchase_plan"])
+	item := asMap(asSlice(plan["menu_items"])[0])
+	if asString(item["category_id"]) != "hardware-category" {
+		t.Fatalf("checkout category_id = %v, want hardware-category", item["category_id"])
+	}
+}
+
 func TestCartAddRejectsUnidentifiableExistingBasket(t *testing.T) {
 	addCalls := 0
 	api := &testWoltAPI{

--- a/internal/cli/commands_checkout.go
+++ b/internal/cli/commands_checkout.go
@@ -219,6 +219,7 @@ func newCheckoutPreviewCommand(deps Dependencies) *cobra.Command {
 				deliveryMode,
 				tip,
 				promoCode,
+				checkoutpayload.WithCurrentCatalog(currentItems),
 			)
 			if err != nil {
 				return emitError(

--- a/internal/mcpserver/cart_checkout_contract_test.go
+++ b/internal/mcpserver/cart_checkout_contract_test.go
@@ -311,6 +311,88 @@ func TestCheckoutRejectsNegativeTipBeforeUpstream(t *testing.T) {
 	}
 }
 
+func TestCheckoutUsesValidatedCatalogCategoryWhenBasketOmitsIt(t *testing.T) {
+	const (
+		venueID = "000000000000000000000361"
+		itemID  = "000000000000000000000362"
+	)
+	assortmentItemCalls := 0
+	var captured map[string]any
+	wolt := &stubWolt{
+		venueStaticFn: func(context.Context, string) (map[string]any, error) {
+			return map[string]any{
+				"venue": map[string]any{
+					"id":       venueID,
+					"slug":     "synthetic-tools-market",
+					"currency": "GEL",
+				},
+			}, nil
+		},
+		basketsPageFn: func(context.Context, domain.Location, woltgateway.AuthContext) (map[string]any, error) {
+			return map[string]any{"baskets": []any{
+				map[string]any{
+					"id": "basket-category-regression",
+					"venue": map[string]any{
+						"id":       venueID,
+						"slug":     "synthetic-tools-market",
+						"currency": "GEL",
+					},
+					"total": "GEL 12.50",
+					"items": []any{
+						map[string]any{
+							"id":    itemID,
+							"name":  "Catalog-only category item",
+							"count": 1,
+							"price": 1250,
+						},
+					},
+				},
+			}}, nil
+		},
+		assortmentItemsFn: func(context.Context, string, []string, woltgateway.AuthContext) (map[string]any, error) {
+			assortmentItemCalls++
+			return map[string]any{"items": []any{
+				map[string]any{
+					"id":                  itemID,
+					"name":                "Catalog-only category item",
+					"price":               1250,
+					"category_id":         "hardware-category",
+					"purchasable_balance": 1,
+				},
+			}}, nil
+		},
+		checkoutPreviewFn: func(_ context.Context, payload map[string]any, _ woltgateway.AuthContext) (map[string]any, error) {
+			captured = payload
+			return map[string]any{
+				"payable_amount": 1250,
+				"delivery_configs": []any{
+					map[string]any{"type": "standard", "selected": true},
+				},
+			}, nil
+		},
+	}
+	tc := regressionMCPToolCtx(wolt)
+
+	_, output, err := tc.handleCheckoutPreview(context.Background(), nil, CheckoutPreviewInput{
+		LocationInput: LocationInput{Lat: 10.25, Lon: 20.5},
+		Venue:         "synthetic-tools-market",
+	})
+	if err != nil {
+		t.Fatalf("handleCheckoutPreview: %v", err)
+	}
+	if output.Status != "ready" {
+		t.Fatalf("checkout output = %#v", output)
+	}
+	if assortmentItemCalls != 1 {
+		t.Fatalf("current-item lookup calls = %d, want 1", assortmentItemCalls)
+	}
+	plan := asMap(captured["purchase_plan"])
+	item := asMap(asSlice(plan["menu_items"])[0])
+	if asString(item["category_id"]) != "hardware-category" {
+		t.Fatalf("checkout category_id = %v, want hardware-category", item["category_id"])
+	}
+}
+
 func TestCartClearUsesBothContainersAndCompatibilityIDs(t *testing.T) {
 	deletedIDs := []string{}
 	wolt := &stubWolt{

--- a/internal/mcpserver/tools_checkout.go
+++ b/internal/mcpserver/tools_checkout.go
@@ -139,7 +139,17 @@ func (tc *ToolCtx) handleCheckoutPreview(ctx context.Context, _ *mcp.CallToolReq
 		}, nil
 	}
 
-	payload, buildWarnings, err := checkoutpayload.Build(ctx, tc.wolt, tc.wolt.VenuePageStatic, basket, loc, deliveryMode, in.Tip, in.PromoCode)
+	payload, buildWarnings, err := checkoutpayload.Build(
+		ctx,
+		tc.wolt,
+		tc.wolt.VenuePageStatic,
+		basket,
+		loc,
+		deliveryMode,
+		in.Tip,
+		in.PromoCode,
+		checkoutpayload.WithCurrentCatalog(currentItems),
+	)
 	if err != nil {
 		return nil, CheckoutPreviewOutput{}, toolErr(err)
 	}

--- a/internal/service/checkoutpayload/checkoutpayload.go
+++ b/internal/service/checkoutpayload/checkoutpayload.go
@@ -14,6 +14,22 @@ import (
 
 type VenuePageStaticFunc func(context.Context, string) (map[string]any, error)
 
+type BuildOption func(*buildOptions)
+
+type buildOptions struct {
+	currentCatalog map[string]any
+}
+
+// WithCurrentCatalog reuses the authenticated current-item payload that the
+// caller already loaded to validate basket availability. Besides avoiding a
+// second lookup, this preserves item metadata such as category_id that the
+// basket payload itself does not carry.
+func WithCurrentCatalog(payload map[string]any) BuildOption {
+	return func(options *buildOptions) {
+		options.currentCatalog = payload
+	}
+}
+
 // maxCheckoutVenueContentPages caps how deep a single preview pages through
 // venue content while hunting for basket item categories.
 const (
@@ -30,7 +46,14 @@ func Build(
 	deliveryMode string,
 	tip int,
 	promoCode string,
+	buildOpts ...BuildOption,
 ) (map[string]any, []string, error) {
+	options := buildOptions{}
+	for _, option := range buildOpts {
+		if option != nil {
+			option(&options)
+		}
+	}
 	if tip < 0 {
 		return nil, nil, fmt.Errorf("tip must be zero or greater")
 	}
@@ -124,8 +147,11 @@ func Build(
 	// A lazily loaded grocery assortment publishes no items, and the item page
 	// carries no sell_by_weight_config, so weighted pricing has to come from an
 	// explicit item lookup keyed by the basket's ids.
-	catalogItemsPayload := map[string]any{}
-	if venueSlug != "" && wolt != nil {
+	catalogItemsPayload := options.currentCatalog
+	if catalogItemsPayload == nil {
+		catalogItemsPayload = map[string]any{}
+	}
+	if len(catalogItemsPayload) == 0 && venueSlug != "" && wolt != nil {
 		basketItemIDs := make([]string, 0, len(basketItems))
 		for _, item := range basketItems {
 			if itemID := strings.TrimSpace(payloadutil.String(item["id"])); itemID != "" {
@@ -211,9 +237,23 @@ func Build(
 			}
 		}
 
-		categoryID := resolveCheckoutCategoryID(item, detail, itemID, categoryIDsByItemID)
+		resolveCategoryID := func() string {
+			if categoryID := resolveCheckoutCategoryID(item, detail, itemID, categoryIDsByItemID); categoryID != "" {
+				return categoryID
+			}
+			if categoryID := resolveCheckoutCategoryIDFromCatalogPayload(catalogItemsPayload, itemID); categoryID != "" {
+				return categoryID
+			}
+			for _, searchPayload := range searchCatalogPayloads {
+				if categoryID := resolveCheckoutCategoryIDFromCatalogPayload(searchPayload, itemID); categoryID != "" {
+					return categoryID
+				}
+			}
+			return resolveCheckoutCategoryIDFromCatalogPayload(assortmentPayload, itemID)
+		}
+		categoryID := resolveCategoryID()
 		for categoryID == "" && (searchCatalogForItem(item) || loadMoreVenueContentCategories()) {
-			categoryID = resolveCheckoutCategoryID(item, detail, itemID, categoryIDsByItemID)
+			categoryID = resolveCategoryID()
 		}
 		if categoryID == "" {
 			return nil, warnings, fmt.Errorf("unable to resolve category_id for basket item %q", itemID)
@@ -382,6 +422,10 @@ func resolveCheckoutCategoryIDFromItemLikePayload(payload map[string]any) string
 		}
 	}
 	return ""
+}
+
+func resolveCheckoutCategoryIDFromCatalogPayload(payload map[string]any, itemID string) string {
+	return resolveCheckoutCategoryIDFromItemLikePayload(catalogitem.Find(payload, itemID))
 }
 
 func resolveBasketVenueSlug(venue map[string]any) string {

--- a/internal/service/checkoutpayload/checkoutpayload_test.go
+++ b/internal/service/checkoutpayload/checkoutpayload_test.go
@@ -674,6 +674,55 @@ func TestBuildEnrichesCategoryFromItemPage(t *testing.T) {
 	}
 }
 
+func TestBuildUsesCategoryFromValidatedCurrentCatalog(t *testing.T) {
+	const itemID = "000000000000000000000416"
+	basket := basketWithItem("GEL 12.50", map[string]any{
+		"id":    itemID,
+		"name":  "Catalog-only category item",
+		"count": 1,
+		"price": 1250,
+	})
+	basket["venue"].(map[string]any)["slug"] = "synthetic-tools-market"
+	basket["venue"].(map[string]any)["currency"] = "GEL"
+
+	api := &fakeAPI{
+		assortmentItemsFn: func(context.Context, string, []string) (map[string]any, error) {
+			t.Fatal("Build repeated the current-item lookup instead of reusing the validated catalog")
+			return nil, nil
+		},
+	}
+	currentCatalog := map[string]any{
+		"items": []any{
+			map[string]any{
+				"id":          itemID,
+				"category_id": "hardware-category",
+			},
+		},
+	}
+
+	payload, warnings, err := Build(
+		context.Background(),
+		api,
+		nil,
+		basket,
+		domain.Location{},
+		"standard",
+		0,
+		"",
+		WithCurrentCatalog(currentCatalog),
+	)
+	if err != nil {
+		t.Fatalf("Build() error = %v (warnings: %v)", err, warnings)
+	}
+	item := firstMenuItem(t, purchasePlan(t, payload))
+	if item["category_id"] != "hardware-category" {
+		t.Fatalf("category_id = %v, want hardware-category", item["category_id"])
+	}
+	if !reflect.DeepEqual(item["category_ids"], []any{"hardware-category"}) {
+		t.Fatalf("category_ids = %#v, want canonical catalog category", item["category_ids"])
+	}
+}
+
 // Grocery venues load categories lazily: the assortment lists categories with
 // empty item_ids, so the item-to-category mapping only exists in venue content.
 func TestBuildResolvesCategoryFromPagedVenueContent(t *testing.T) {


### PR DESCRIPTION
## Summary

- reuse the authenticated current-catalog payload already loaded during basket availability validation
- resolve missing basket `category_id` directly from the scoped catalog item
- apply the same behavior to both CLI and MCP checkout preview
- avoid a duplicate current-item lookup when validated catalog data is available

## Problem

Wolt basket payloads do not always include `category_id` on their item rows, even though the current assortment item contains it.

Both the CLI and MCP checkout paths already fetched the current items to validate basket availability, but discarded that payload before calling the shared checkout builder.

The builder then performed another lookup and used catalog item records for weighted pricing only, not category resolution. If the category was not also discoverable through category containers, item search, or paged venue content, checkout failed with:

```text
unable to resolve category_id for basket item "<item-id>"
```

Cart mutations and cart display continued to work; only checkout preview was affected.

## Fix

The checkout builder now accepts the already validated current-catalog payload from its caller.

Category resolution now:

1. preserves an explicit category from the basket or item-detail payload;
2. resolves the category directly from the scoped current-catalog item;
3. applies the same direct-item resolution to search and assortment fallbacks;
4. retains the existing category-container and venue-content fallbacks;
5. still fails closed when no authoritative category can be found.

No venue- or category-specific exceptions are introduced.

## Tests

Added regression coverage for a basket item that:

- has no `category_id` in the basket payload;
- has a valid `category_id` in the current-catalog response.

The scenario is covered at three levels:

- shared checkout payload builder;
- CLI checkout handler;
- MCP checkout handler.

The CLI and MCP tests also assert that the validated current-item lookup is reused rather than repeated.

Validation completed:

- `go mod download`
- `go build ./...`
- `go vet ./...`
- `go test -count=1 ./...`
- `go test -race -count=1 ./...`
- golangci-lint v2.4.0: `0 issues`
- read-only live CLI checkout preview
- read-only live MCP stdio checkout preview
