### PR TITLE
ci(release): attest build provenance for release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -82,6 +82,11 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
 
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -177,6 +182,13 @@ jobs:
             echo "- \`SHA256SUMS\` contains checksums for all release archives."
             echo "- \`wolt-cli_skill_${CURRENT_TAG}.zip\` contains the AI agent skill bundle."
           } > RELEASE_NOTES.md
+
+      - name: Attest build provenance
+        uses: actions/attest@v4
+        with:
+          subject-path: |
+            dist/*.tar.gz
+            dist/*.zip
 
       - name: Publish release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## What

Adds a GitHub build provenance attestation step to the publishing job in `release.yml`, covering the four platform archives and the skill bundle.

## Why

Right now `SHA256SUMS` is the only integrity anchor a release carries, and it sits in the same release published by the same identity — it catches a corrupted download, not a compromised release. Attestations bind each asset to the specific workflow run that built it, and consumers check them automatically: mise's `github:` backend runs a `verify GitHub artifact attestations` step on install, which currently has nothing to verify here.

## Notes

- Uses `actions/attest` rather than `actions/attest-build-provenance`. As of v4 the latter is a wrapper that forwards empty predicate inputs, and its README asks new implementations to use `actions/attest` directly. Behaviour is identical here — with no predicate given, `actions/attest` emits build provenance.
- Permissions are added on the `release` job only (where the files actually exist after `download-artifact`), so the workflow-level scope stays `contents: write` and the other jobs are untouched. `artifact-metadata: write` is not requested: the storage record it covers requires `push-to-registry`, which only applies to OCI image subjects.
- Subjects are `dist/*.tar.gz` and `dist/*.zip`. `SHA256SUMS` is deliberately left out — it's a manifest over those same files, and attesting the artifacts directly is what `gh attestation verify <file>` checks.
- Pinned to `@v4`, matching how the other actions here are pinned by major.

## Verification — and its limit

`actionlint` passes on the changed file and on all workflows (clean before and after), the YAML parses, and the step matches the action's documented inputs.

**This is not verified end to end** — an attestation is only issued on a real tag push, so the path can't be exercised from a PR. What will confirm it: the next `v*` release shows the attestation in the run summary, and `gh attestation verify <archive> --repo mekedron/wolt-cli` succeeds (today it returns 404, since no attestations exist).
